### PR TITLE
Restrict shapes for CAST_FROM_BLOCK_SCALED

### DIFF
--- a/pseudocode/operators/CAST_FROM_BLOCK_SCALED.tosac
+++ b/pseudocode/operators/CAST_FROM_BLOCK_SCALED.tosac
@@ -8,6 +8,12 @@
 // by a licensing agreement from ARM Limited.
 
 ERROR_IF(rank(shape) == 0 || shape[rank(shape)-1] % block_size != 0);
+ERROR_IF(rank(shape) != rank(in_scale_shape));
+
+for (int32_t axis_index = 0; axis_index < rank(shape) - 1; axis_index++) {
+    ERROR_IF(shape[axis_index] != in_scale_shape[axis_index]);
+}
+ERROR_IF(shape[rank(shape) - 1] != in_scale_shape[rank(shape) - 1] * block_size);
 
 for_each_data_position(index in shape) {
 

--- a/tosa.xml
+++ b/tosa.xml
@@ -3217,7 +3217,7 @@ used.</description>
             <rank min="1" max="MAX_RANK"/>
           </argument>
           <argument category="input" name="input_scale" type="tensor_t" shape="in_scale_shape" tensor-element-type="scale_t">
-            <description>Input scale values tensor</description>
+            <description>Input scale values tensor with the same rank as input_data</description>
             <levellimit value="rank(input_scale)" limit="MAX_RANK"/>
             <rank min="1" max="MAX_RANK"/>
           </argument>


### PR DESCRIPTION
Add restrictions to ensure ranks for input_data and input_scale match, and also that the shapes are related in the expected way, matching everywhere except the last axis, in which the axis for in_scale should be block_size times smaller than the one for in_data.


Change-Id: Id036aff163d1130ecda11169b716b3c26372b4b1