### PR TITLE
Generalize checks for finite and NaN-less types

### DIFF
--- a/pseudocode/library/generic_helpers.tosac
+++ b/pseudocode/library/generic_helpers.tosac
@@ -15,6 +15,26 @@ bool_t is_floating_point<type>() {
     return false;
 }
 
+bool_t has_Inf<in_t>() {
+  if (is_same<in_t, fp8e4m3_t>() || is_same<in_t, fp6e2m3_t>() || is_same<in_t, fp6e3m2_t>() || is_same<in_t, fp4e2m1_t>() || is_same<in_t, mxint8_t>()) {
+    return false;
+  }
+  if (is_floating_point<in_t>()) {
+    return true;
+  }
+  return false;
+}
+
+bool_t has_NaN<in_t>() {
+  if (is_same<in_t, fp6e2m3_t>() || is_same<in_t, fp6e3m2_t>() || is_same<in_t, fp4e2m1_t>() || is_same<in_t, mxint8_t>()) {
+    return false;
+  }
+  if (is_floating_point<in_t>()) {
+    return true;
+  }
+  return false;
+}
+
 int32_t idiv(int32_t input1, int32_t input2) {
     return input1 / input2; // Integer divide that truncates towards zero
 }

--- a/pseudocode/library/tosa_reference_check.tosac
+++ b/pseudocode/library/tosa_reference_check.tosac
@@ -59,8 +59,7 @@ bool_t tosa_reference_check_scale<scale_t, out_t>(fp64_t test_scale, fp64_t test
 
 bool_t tosa_reference_check_fp_bnd<in_t>(in_t test_value, fp64_t ref_value, fp64_t err_bnd) {
   if (is_a_NaN(ref_value)) {
-    if (is_same<in_t, mxint8_t>()) {
-      // mxint8_t does not have a NaN representation. Allow any result.
+    if (!has_NaN<in_t>()) {
       return true;
     }
     // If the reference value is a NaN, the test value must also be any NaN.
@@ -81,9 +80,7 @@ bool_t tosa_reference_check_fp_bnd<in_t>(in_t test_value, fp64_t ref_value, fp64
   fp64_t ref_max = ref_value + err_bnd;
   fp64_t ref_min = ref_value - err_bnd;
 
-  if (is_same<in_t, mxint8_t>()) {
-    // mxint8_t does not have infinity, clamp to the largest valid value.
-
+  if (!has_Inf<in_t>() && !has_NaN<in_t>()) {
     if (ref_max > normal_max<in_t>()) ref_max = normal_max<in_t>();
     if (ref_min > normal_max<in_t>()) ref_min = normal_max<in_t>();
     if (ref_min < -normal_max<in_t>()) ref_min = -normal_max<in_t>();
@@ -94,11 +91,11 @@ bool_t tosa_reference_check_fp_bnd<in_t>(in_t test_value, fp64_t ref_value, fp64
   }
 
   if (is_same<in_t,bf16_t>() || is_same<in_t,fp16_t>() || is_same<in_t,fp32_t>()) {
-    // Allow subnormal values to be flushed to zero for non-fp8
+    // Allow subnormal values to be flushed to zero for these types
     if (test_value == 0) return (ref_min < normal_min<in_t>());
   }
 
-  if (is_same<in_t,fp8e4m3_t>() && is_a_NaN(test_value)) {
+  if (is_a_NaN(test_value) && !has_Inf<in_t>()) {
     // The case where ref is NaN is handled at the beginning of the function
     // The following check is enough because `abs(ref_max) >= abs(ref_min)` and
     // `ref_max >= 0`.


### PR DESCRIPTION
* Add has_NaN<in_t>() and has_Inf<in_t>() helpers.
* Generalize tosa_reference_check code to use these helpers instead of referring to specific datatypes. This means that some of the special code that was only used for mxint8_t in the past now applies to other types that lack NaNs and/or Infs.


Change-Id: Iaecf9260fe412680e6ca62b13805ab023bcea48c