### PR TITLE
Deal with asymmetric types in tosa_reference_check

### DIFF
--- a/pseudocode/library/numeric_accuracy_helpers.tosac
+++ b/pseudocode/library/numeric_accuracy_helpers.tosac
@@ -73,6 +73,14 @@ fp64_t normal_max<in_t>() {
   }
 }
 
+fp64_t normal_lowest<in_t>() {
+  if (is_same<in_t,mxint8_t>()) {
+    return -2.0;
+  } else {
+    return -normal_max<in_t>();
+  }
+}
+
 // Number of fractional (mantissa bits)
 int normal_frac<in_t>() {
   if (is_same<in_t,fp32_t>()) {

--- a/pseudocode/library/tosa_reference_check.tosac
+++ b/pseudocode/library/tosa_reference_check.tosac
@@ -71,6 +71,9 @@ bool_t tosa_reference_check_fp_bnd<in_t>(in_t test_value, fp64_t ref_value, fp64
 
   fp64_t test_value64 = static_cast<fp64_t>(test_value);
 
+  fp64_t ref_high_cap = ref_value < 0.0 ? -normal_lowest<in_t>() : normal_max<in_t>();
+  fp64_t ref_low_cap = ref_value < 0.0 ? -normal_max<in_t>() : normal_lowest<in_t>() ;
+
   REQUIRE(err_bnd >= 0.0);
   if (ref_value < 0.0) {
     ref_value  = -ref_value;
@@ -81,13 +84,13 @@ bool_t tosa_reference_check_fp_bnd<in_t>(in_t test_value, fp64_t ref_value, fp64
   fp64_t ref_min = ref_value - err_bnd;
 
   if (!has_Inf<in_t>() && !has_NaN<in_t>()) {
-    if (ref_max > normal_max<in_t>()) ref_max = normal_max<in_t>();
-    if (ref_min > normal_max<in_t>()) ref_min = normal_max<in_t>();
-    if (ref_min < -normal_max<in_t>()) ref_min = -normal_max<in_t>();
+    if (ref_max > ref_high_cap) ref_max = ref_high_cap;
+    if (ref_min > ref_high_cap) ref_min = ref_high_cap;
+    if (ref_min < ref_low_cap) ref_min = ref_low_cap;
   } else {
-    if (ref_max > normal_max<in_t>()) ref_max = infinity;
-    if (ref_min > normal_max<in_t>()) ref_min = infinity;
-    if (ref_min < -normal_max<in_t>()) ref_min = -infinity;
+    if (ref_max > ref_high_cap) ref_max = infinity;
+    if (ref_min > ref_high_cap) ref_min = infinity;
+    if (ref_min < ref_low_cap) ref_min = -infinity;
   }
 
   if (is_same<in_t,bf16_t>() || is_same<in_t,fp16_t>() || is_same<in_t,fp32_t>()) {


### PR DESCRIPTION
For mxint8, the lowest value is lower than -normal_max<mxint8_t>(), which means that when we normalise the sign to positive, we lose some of the range. Change the capping checks to use `-normal_lowest<in_t>()` instead when the test value is negative.


Change-Id: I431b2db9df7579a6ce093c8f63b6b6063673d9c3