### PR TITLE
Add support for fp32 accumulation of fp8 convolution operators

### DIFF
--- a/tosa.xml
+++ b/tosa.xml
@@ -316,6 +316,12 @@
         <typesupport mode="fp8e5m2 with fp16 accumulate" in_t="fp8e5m2_t" weight_t="fp8e5m2_t" out_t="fp16_t" acc_t="fp16_t" version_added="1.0">
           <op_profile name="EXT-FP8E5M2"/>
         </typesupport>
+        <typesupport mode="fp8e4m3 with fp32 accumulate" in_t="fp8e4m3_t" weight_t="fp8e4m3_t" out_t="fp32_t" acc_t="fp32_t" version_added="1.1">
+          <op_profile name="EXT-FP8E4M3"/>
+        </typesupport>
+        <typesupport mode="fp8e5m2 with fp32 accumulate" in_t="fp8e5m2_t" weight_t="fp8e5m2_t" out_t="fp32_t" acc_t="fp32_t" version_added="1.1">
+          <op_profile name="EXT-FP8E5M2"/>
+        </typesupport>
         <typesupport mode="fp16 with fp16 accumulate" in_t="fp16_t" weight_t="fp16_t" out_t="fp16_t" acc_t="fp16_t" version_added="1.0">
           <op_profile name="PRO-FP"/>
         </typesupport>
@@ -427,6 +433,12 @@
         <typesupport mode="fp8e5m2 with fp16 accumulate" in_t="fp8e5m2_t" weight_t="fp8e5m2_t" out_t="fp16_t" acc_t="fp16_t" version_added="1.0">
           <op_profile name="EXT-FP8E5M2"/>
         </typesupport>
+        <typesupport mode="fp8e4m3 with fp32 accumulate" in_t="fp8e4m3_t" weight_t="fp8e4m3_t" out_t="fp32_t" acc_t="fp32_t" version_added="1.1">
+          <op_profile name="EXT-FP8E4M3"/>
+        </typesupport>
+        <typesupport mode="fp8e5m2 with fp32 accumulate" in_t="fp8e5m2_t" weight_t="fp8e5m2_t" out_t="fp32_t" acc_t="fp32_t" version_added="1.1">
+          <op_profile name="EXT-FP8E5M2"/>
+        </typesupport>
         <typesupport mode="fp16 with fp16 accumulate" in_t="fp16_t" weight_t="fp16_t" out_t="fp16_t" acc_t="fp16_t" version_added="1.0">
           <op_profile name="PRO-FP"/>
         </typesupport>
@@ -532,6 +544,12 @@
           <op_profile name="EXT-FP8E4M3"/>
         </typesupport>
         <typesupport mode="fp8e5m2 with fp16 accumulate" in_t="fp8e5m2_t" weight_t="fp8e5m2_t" out_t="fp16_t" acc_t="fp16_t" version_added="1.0">
+          <op_profile name="EXT-FP8E5M2"/>
+        </typesupport>
+        <typesupport mode="fp8e4m3 with fp32 accumulate" in_t="fp8e4m3_t" weight_t="fp8e4m3_t" out_t="fp32_t" acc_t="fp32_t" version_added="1.1">
+          <op_profile name="EXT-FP8E4M3"/>
+        </typesupport>
+        <typesupport mode="fp8e5m2 with fp32 accumulate" in_t="fp8e5m2_t" weight_t="fp8e5m2_t" out_t="fp32_t" acc_t="fp32_t" version_added="1.1">
           <op_profile name="EXT-FP8E5M2"/>
         </typesupport>
         <typesupport mode="fp16 with fp16 accumulate" in_t="fp16_t" weight_t="fp16_t" out_t="fp16_t" acc_t="fp16_t" version_added="1.0">
@@ -907,6 +925,12 @@
           <op_profile name="EXT-FP8E4M3"/>
         </typesupport>
         <typesupport mode="fp8e5m2 with fp16 accumulate" in_t="fp8e5m2_t" weight_t="fp8e5m2_t" out_t="fp16_t" acc_t="fp16_t" version_added="1.0">
+          <op_profile name="EXT-FP8E5M2"/>
+        </typesupport>
+        <typesupport mode="fp8e4m3 with fp32 accumulate" in_t="fp8e4m3_t" weight_t="fp8e4m3_t" out_t="fp32_t" acc_t="fp32_t" version_added="1.1">
+          <op_profile name="EXT-FP8E4M3"/>
+        </typesupport>
+        <typesupport mode="fp8e5m2 with fp32 accumulate" in_t="fp8e5m2_t" weight_t="fp8e5m2_t" out_t="fp32_t" acc_t="fp32_t" version_added="1.1">
           <op_profile name="EXT-FP8E5M2"/>
         </typesupport>
         <typesupport mode="fp16 with fp16 accumulate" in_t="fp16_t" weight_t="fp16_t" out_t="fp16_t" acc_t="fp16_t" version_added="1.0">


### PR DESCRIPTION
Includes support for CONV2D, CONV3D, DEPTHWISE_CONV2D and TRANSPOSE_CONV2D.


Change-Id: Idb3f54a2af63ab23b04035f25eefe271617087b1