### PR TITLE
Update LOG2_CEIL and LOG2_FLOOR shape op pseudocode

### DIFF
--- a/pseudocode/operators/LOG2_CEIL_SHAPE.tosac
+++ b/pseudocode/operators/LOG2_CEIL_SHAPE.tosac
@@ -7,9 +7,7 @@
 // copies and copies may only be made to the extent permitted
 // by a licensing agreement from ARM Limited.
 
-ERROR_IF(length(input1) != length(input2));
-
-for(int32_t index=0; index < length(input1); index++) {
+for(int32_t index=0; index < length(input); index++) {
     tensor_size_t log_val = 0;
     tensor_size_t in = input[index];
     REQUIRE(in >= 1);

--- a/pseudocode/operators/LOG2_FLOOR_SHAPE.tosac
+++ b/pseudocode/operators/LOG2_FLOOR_SHAPE.tosac
@@ -7,9 +7,7 @@
 // copies and copies may only be made to the extent permitted
 // by a licensing agreement from ARM Limited.
 
-ERROR_IF(length(input1) != length(input2));
-
-for(int32_t index=0; index < length(input1); index++) {
+for(int32_t index=0; index < length(input); index++) {
     tensor_size_t log_val = 0;
     tensor_size_t in = input[index];
     REQUIRE(in >= 1);


### PR DESCRIPTION
For the LOG2 shape ops:
- These ops take only one input, so removed the redundant ERROR_IF check.


Change-Id: I2dcda9f4a43c75fca631e7da58be11a507acc267
