### PR TITLE
Add a REQUIRE to DIM to check for invalid dim size

### DIFF
--- a/pseudocode/operators/DIM.tosac
+++ b/pseudocode/operators/DIM.tosac
@@ -9,4 +9,5 @@
 
 ERROR_IF(axis >= rank(shape));
 ERROR_IF(axis < 0);
+REQUIRE(shape[axis] > 0);
 output[0] = shape_dim(shape, axis);


### PR DESCRIPTION
This commit adds an evaluation time check to make sure DIM doesn't return a non-positive value. While shape_t allows zero to be used for parameters like padding and negative values to be "used for negative offsets" in operations such as resize, it does not make sense for the dim of a tensor to be zero or negative at the time of runtime execution. Adding this check allows software implementations to reserve negative dims in a tensor shape for other purposes, such as representing a
dynamic dimension that is yet to be resolved.