### PR TITLE
Align CONCAT_SHAPE input name to "input"

### DIFF
--- a/chapters/shape.adoc
+++ b/chapters/shape.adoc
@@ -1,7 +1,7 @@
 //
 // This confidential and proprietary software may be used only as
 // authorised by a licensing agreement from ARM Limited
-// (C) COPYRIGHT 2024 ARM Limited
+// (C) COPYRIGHT 2024-2025 ARM Limited
 // ALL RIGHTS RESERVED
 // The entire notice above must be reproduced on all authorised
 // copies and copies may only be made to the extent permitted
@@ -38,7 +38,7 @@ include::{pseudocode}/operators/ASSERT_EQUAL_SHAPE.tosac[lines=10..-1]
 
 ==== CONCAT_SHAPE
 
-Concatenates a list of shape_t to create a new shape_t with length the sum of lengths of all shape_t in input1.
+Concatenates a list of shape_t to create a new shape_t with length the sum of lengths of all shape_t in input.
 
 include::{generated}/operators/CONCAT_SHAPE.adoc[]
 

--- a/pseudocode/operators/CONCAT_SHAPE.tosac
+++ b/pseudocode/operators/CONCAT_SHAPE.tosac
@@ -7,12 +7,12 @@
 // copies and copies may only be made to the extent permitted
 // by a licensing agreement from ARM Limited.
 
-ERROR_IF(length(output) != sum(length(input1[k]) for all k));
+ERROR_IF(length(output) != sum(length(input[k]) for all k));
 
 tensor_size_t index = 0;
-for (int32_t i=0; i < length(input1); i++) {
-    for (int32_t j=0; j < length(input1[i]); j++) {
-        output[index] = input1[i][j];
+for (int32_t i=0; i < length(input); i++) {
+    for (int32_t j=0; j < length(input[i]); j++) {
+        output[index] = input[i][j];
         index++;
     }
 }


### PR DESCRIPTION
In several places the input was referred to as "input1", but the name of the input in the arguments table is "input". This commit aligns all instances to "input".