### PR TITLE
Add new AVG_POOL2D_ADAPTIVE and MAX_POOL2D_ADAPTIVE

### DIFF
--- a/chapters/tensor_ops.adoc
+++ b/chapters/tensor_ops.adoc
@@ -59,6 +59,30 @@ include::{generated}/operators/AVG_POOL2D.adoc[]
 include::{pseudocode}/operators/AVG_POOL2D.tosac[lines=10..-1]
 ----
 
+==== AVG_POOL2D_ADAPTIVE
+
+This performs an average pooling over the given input tensor.
+A sliding window of size given by <kernel size> is passed over the input tensor, with the mean value being placed in the output tensor.
+When calculating the average, only the number of valid input tensor values, but not padding, are used to calculate the divisor.
+Compared to AVG_POOL2D, AVG_POOL2D_ADAPTIVE has the kernel, stride, pad arguments as inputs rather than attributes.
+
+*Precision Requirements*
+
+Integer results must be exact.
+
+For floating-point values, the following rules apply:
+
+* Subnormal bf16_t, fp16_t, and fp32_t input values may be flushed to zero before calculation.
+* Outputs can be expressed as a dot product of an input vector with a vector with elements 1/KS where KS is the kernel size.
+* This dot product must meet the <<Dot product accuracy requirements>>.
+
+include::{generated}/operators/AVG_POOL2D_ADAPTIVE.adoc[]
+
+[source,c++]
+----
+include::{pseudocode}/operators/AVG_POOL2D.tosac[lines=10..-1]
+----
+
 ==== CONV2D
 
 Performs a 2D convolution over the given tensor input, using the weight tensor.
@@ -231,6 +255,38 @@ Otherwise the result is the maximum non-NaN value in the window.
 * If the result is a subnormal value for bf16_t, fp16_t, or fp32_t, the result may be a zero of either sign.
 
 include::{generated}/operators/MAX_POOL2D.adoc[]
+
+[source,c++]
+----
+include::{pseudocode}/operators/MAX_POOL2D.tosac[lines=10..-1]
+----
+
+==== MAX_POOL2D_ADAPTIVE
+
+This performs a max pooling over the given input tensor.
+A sliding window of size given by <kernel size> is passed over the input tensor, with the maximum value being placed in the output tensor.
+Compared to MAX_POOL2D, MAX_POOL2D_ADAPTIVE has the kernel, stride, pad arguments as inputs rather than attributes.
+
+*Precision Requirements*
+
+Integer results must be exact.
+
+NaN propagation mode only affects floating-point types.
+It indicates either propagating or ignoring NaN.
+
+The following rules apply to floating-point inputs:
+
+* Comparison rules:
+** The sign of a zero is ignored.
+** Infinities of the same sign compare as equal.
+** In the NaN propagating mode, if any input in the window is a NaN then the result must be NaN.
+** In the NaN ignoring mode, if all inputs in the window are NaN, the result is NaN.
+Otherwise the result is the maximum non-NaN value in the window.
+* Subnormal bf16_t, fp16_t, and fp32_t input values may be flushed to zero before calculation.
+* If a floating-point result is zero, then the result must be either +0.0 or -0.0 but either sign is permitted.
+* If the result is a subnormal value for bf16_t, fp16_t, or fp32_t, the result may be a zero of either sign.
+
+include::{generated}/operators/MAX_POOL2D_ADAPTIVE.adoc[]
 
 [source,c++]
 ----

--- a/tools/compliance_data_verifier.py
+++ b/tools/compliance_data_verifier.py
@@ -8,6 +8,7 @@ import regex
 op_list = [
     "argmax",
     "avg_pool2d",
+    "avg_pool2d_adaptive",
     "conv2d",
     "conv3d",
     "depthwise_conv2d",
@@ -15,6 +16,7 @@ op_list = [
     "fully_connected",
     "matmul",
     "max_pool2d",
+    "max_pool2d_adaptive",
     "rfft2d",
     "transpose_conv2d",
     "clamp",

--- a/tosa.xml
+++ b/tosa.xml
@@ -222,6 +222,113 @@
           <op_profile name="PRO-FP"/>
         </typesupport>
       </operator>
+     <operator>
+        <name>AVG_POOL2D_ADAPTIVE</name>
+        <arguments>
+          <argument category="input" name="input" type="tensor_t" shape="[N,IH,IW,C]" tensor-element-type="in_out_t">
+            <description>Input tensor</description>
+            <rank min="4" max="4"/>
+          </argument>
+          <argument category="input" name="input_zp" type="tensor_t" shape="[1]" tensor-element-type="in_out_t">
+            <description>Input tensor zero point. Must be zero for non-int8 types.</description>
+            <rank min="1" max="1"/>
+            <ctc>
+              <op_profile name="PRO-INT"/>
+              <op_profile name="PRO-FP"/>
+            </ctc>
+            <ctc_remove>
+              <op_profile name="EXT-DYNAMIC"/>
+            </ctc_remove>
+          </argument>
+          <argument category="input" name="output_zp" type="tensor_t" shape="[1]" tensor-element-type="in_out_t">
+            <description>Output tensor zero point. Must be zero for non-int8 types.</description>
+            <rank min="1" max="1"/>
+            <ctc>
+              <op_profile name="PRO-INT"/>
+              <op_profile name="PRO-FP"/>
+            </ctc>
+            <ctc_remove>
+              <op_profile name="EXT-DYNAMIC"/>
+            </ctc_remove>
+          </argument>
+          <argument category="input" name="kernel" type="tensor_t" shape="[2]" tensor-element-type="i32_t">
+            <description>[kernel_y, kernel_x]</description>
+            <levellimit value="kernel_y" limit="MAX_KERNEL"/>
+            <levellimit value="kernel_x" limit="MAX_KERNEL"/>
+            <rank min="1" max="1"/>
+            <ctc>
+              <op_profile name="PRO-INT"/>
+              <op_profile name="PRO-FP"/>
+            </ctc>
+            <ctc_remove>
+              <op_profile name="EXT-DYNAMIC"/>
+            </ctc_remove>
+          </argument>
+          <argument category="input" name="stride" type="tensor_t" shape="[2]" tensor-element-type="i32_t">
+            <description>[stride_y, stride_x]</description>
+            <levellimit value="stride_y" limit="MAX_STRIDE"/>
+            <levellimit value="stride_x" limit="MAX_STRIDE"/>
+            <rank min="1" max="1"/>
+            <ctc>
+              <op_profile name="PRO-INT"/>
+              <op_profile name="PRO-FP"/>
+            </ctc>
+            <ctc_remove>
+              <op_profile name="EXT-DYNAMIC"/>
+            </ctc_remove>
+          </argument>
+          <argument category="input" name="pad" type="tensor_t" shape="[4]" tensor-element-type="i32_t">
+            <description>[pad_top, pad_bottom, pad_left, pad_right]</description>
+            <levellimit value="pad_top"    limit="MAX_KERNEL"/>
+            <levellimit value="pad_bottom" limit="MAX_KERNEL"/>
+            <levellimit value="pad_left"   limit="MAX_KERNEL"/>
+            <levellimit value="pad_right"  limit="MAX_KERNEL"/>
+            <rank min="1" max="1"/>
+            <ctc>
+              <op_profile name="PRO-INT"/>
+              <op_profile name="PRO-FP"/>
+            </ctc>
+            <ctc_remove>
+              <op_profile name="EXT-DYNAMIC"/>
+            </ctc_remove>
+          </argument>
+          <argument category="attribute" name="acc_type" type="acc_type_t" shape="-" tensor-element-type="-">
+            <description>Enumerated type, must be one of INT32, FP16, FP32 matching the type of acc_t in the Supported Data Types table for this operation</description>
+          </argument>
+          <argument category="output" name="output" type="tensor_t" shape="[N,OH,OW,C]" tensor-element-type="in_out_t">
+            <description>Output tensor 4D</description>
+            <rank min="4" max="4"/>
+          </argument>
+        </arguments>
+        <types>
+          <type name='in_out_t' />
+          <type name='acc_t' />
+        </types>
+        <typesupport mode="signed 8 with int32 accumulate" in_out_t="i8_t" acc_t="i32_t"  version_added="1.1">
+          <op_profile name="PRO-INT"/>
+        </typesupport>
+        <typesupport mode="signed 16 with int32 accumulate" in_out_t="i16_t" acc_t="i32_t" version_added="1.1">
+          <op_profile name="EXT-INT16"/>
+        </typesupport>
+        <typesupport mode="fp8e4m3 with fp16 accumulate" in_out_t="fp8e4m3_t" acc_t="fp16_t" version_added="1.1">
+          <op_profile name="EXT-FP8E4M3"/>
+        </typesupport>
+        <typesupport mode="fp8e5m2 with fp16 accumulate" in_out_t="fp8e5m2_t" acc_t="fp16_t" version_added="1.1">
+          <op_profile name="EXT-FP8E5M2"/>
+        </typesupport>
+        <typesupport mode="fp16 with fp16 accumulate" in_out_t="fp16_t" acc_t="fp16_t" version_added="1.1">
+          <op_profile name="PRO-FP"/>
+        </typesupport>
+        <typesupport mode="fp16 with fp32 accumulate" in_out_t="fp16_t" acc_t="fp32_t" version_added="1.1">
+          <op_profile name="PRO-FP"/>
+        </typesupport>
+        <typesupport mode="bf16 with fp32 accumulate" in_out_t="bf16_t" acc_t="fp32_t" version_added="1.1">
+          <op_profile name="EXT-BF16"/>
+        </typesupport>
+        <typesupport mode="fp32 with fp32 accumulate" in_out_t="fp32_t" acc_t="fp32_t" version_added="1.1">
+          <op_profile name="PRO-FP"/>
+        </typesupport>
+      </operator>
       <operator>
         <name>CONV2D</name>
         <arguments>
@@ -802,6 +909,90 @@
           <op_profile name="EXT-BF16"/>
         </typesupport>
         <typesupport mode="fp32" in_out_t="fp32_t"  version_added="1.0">
+          <op_profile name="PRO-FP"/>
+        </typesupport>
+      </operator>
+      <operator>
+        <name>MAX_POOL2D_ADAPTIVE</name>
+        <arguments>
+          <argument category="input" name="input" type="tensor_t" shape="[N,IH,IW,C]" tensor-element-type="in_out_t">
+            <description>Input tensor 4D</description>
+            <rank min="4" max="4"/>
+          </argument>
+          <argument category="input" name="kernel" type="tensor_t" shape="[2]" tensor-element-type="i32_t">
+            <description>[kernel_y, kernel_x]</description>
+            <levellimit value="kernel_y" limit="MAX_KERNEL"/>
+            <levellimit value="kernel_x" limit="MAX_KERNEL"/>
+            <rank min="1" max="1"/>
+            <ctc>
+              <op_profile name="PRO-INT"/>
+              <op_profile name="PRO-FP"/>
+            </ctc>
+            <ctc_remove>
+              <op_profile name="EXT-DYNAMIC"/>
+            </ctc_remove>
+          </argument>
+          <argument category="input" name="stride" type="tensor_t" shape="[2]" tensor-element-type="i32_t">
+            <description>[stride_y, stride_x]</description>
+            <levellimit value="stride_y" limit="MAX_STRIDE"/>
+            <levellimit value="stride_x" limit="MAX_STRIDE"/>
+            <rank min="1" max="1"/>
+            <ctc>
+              <op_profile name="PRO-INT"/>
+              <op_profile name="PRO-FP"/>
+            </ctc>
+            <ctc_remove>
+              <op_profile name="EXT-DYNAMIC"/>
+            </ctc_remove>
+          </argument>
+          <argument category="input" name="pad" type="tensor_t" shape="[4]" tensor-element-type="i32_t">
+            <description>[pad_top, pad_bottom, pad_left, pad_right]</description>
+            <levellimit value="pad_top"    limit="MAX_KERNEL"/>
+            <levellimit value="pad_bottom" limit="MAX_KERNEL"/>
+            <levellimit value="pad_left"   limit="MAX_KERNEL"/>
+            <levellimit value="pad_right"  limit="MAX_KERNEL"/>
+            <rank min="1" max="1"/>
+            <ctc>
+              <op_profile name="PRO-INT"/>
+              <op_profile name="PRO-FP"/>
+            </ctc>
+            <ctc_remove>
+              <op_profile name="EXT-DYNAMIC"/>
+            </ctc_remove>
+          </argument>
+          <argument category="attribute" name="nan_mode" type="nan_propagation_mode_t" shape="-" tensor-element-type="-">
+            <description>
+                PROPAGATE or IGNORE. Set to PROPAGATE by default.
+                This attribute affects the floating-point NaN propagation approach. This attribute is ignored by non floating-point types.
+            </description>
+          </argument>
+          <argument category="output" name="output" type="tensor_t" shape="[N,OH,OW,C]" tensor-element-type="in_out_t">
+            <description>Output tensor 4D</description>
+            <rank min="4" max="4"/>
+          </argument>
+        </arguments>
+        <types>
+          <type name='in_out_t' />
+        </types>
+        <typesupport mode="signed 8" in_out_t="i8_t" version_added="1.1">
+          <op_profile name="PRO-INT"/>
+        </typesupport>
+        <typesupport mode="signed 16" in_out_t="i16_t" version_added="1.1">
+          <op_profile name="EXT-INT16"/>
+        </typesupport>
+        <typesupport mode="fp8e4m3" in_out_t="fp8e4m3_t" version_added="1.1">
+          <op_profile name="EXT-FP8E4M3"/>
+        </typesupport>
+        <typesupport mode="fp8e5m2" in_out_t="fp8e5m2_t" version_added="1.1">
+          <op_profile name="EXT-FP8E5M2"/>
+        </typesupport>
+        <typesupport mode="fp16" in_out_t="fp16_t"  version_added="1.1">
+          <op_profile name="PRO-FP"/>
+        </typesupport>
+        <typesupport mode="bf16" in_out_t="bf16_t"  version_added="1.1">
+          <op_profile name="EXT-BF16"/>
+        </typesupport>
+        <typesupport mode="fp32" in_out_t="fp32_t"  version_added="1.1">
           <op_profile name="PRO-FP"/>
         </typesupport>
       </operator>


### PR DESCRIPTION
These versions allow the kernel size, stride, and pad arguments to be compile time constant inputs rather than attributes.


Change-Id: Ie5bf5458679690308cfdde47407e77fbdfdb31ce