### PR TITLE
Break EXT-MXFP into multiple extensions

### DIFF
--- a/tools/compliance_data_exporter.py
+++ b/tools/compliance_data_exporter.py
@@ -18,7 +18,13 @@ validation_term_mapping_profile = {
     "EXT-FFT": "Extension::fft",
     "EXT-SHAPE": "Extension::shape",
     "EXT-VARIABLE": "Extension::variable",
-    "EXT-MXFP": "Extension::mxfp",
+    "EXT-MX-COMMON": "Extension::mxfp_common",
+    "EXT-MX-FP4E2M1": "Extension::mx_fp4e2m1",
+    "EXT-MX-FP6E2M3": "Extension::mx_fp6e2m3",
+    "EXT-MX-FP6E3M2": "Extension::mx_fp6e3m2",
+    "EXT-MX-FP8E4M3": "Extension::mx_fp8e4m3",
+    "EXT-MX-FP8E5M2": "Extension::mx_fp8e5m2",
+    "EXT-MX-INT8": "Extension::mx_int8",
     "EXT-MXFP-CONV": "Extension::mxfp_conv",
 }
 

--- a/tools/compliance_data_verifier.py
+++ b/tools/compliance_data_verifier.py
@@ -106,7 +106,13 @@ profile_list = [
     "Extension::fft",
     "Extension::variable",
     "Extension::shape",
-    "Extension::mxfp",
+    "Extension::mxfp_common",
+    "Extension::mx_fp4e2m1",
+    "Extension::mx_fp6e2m3",
+    "Extension::mx_fp6e3m2",
+    "Extension::mx_fp8e4m3",
+    "Extension::mx_fp8e5m2",
+    "Extension::mx_int8",
     "Extension::mxfp_conv",
 ]
 

--- a/tools/tosa.py
+++ b/tools/tosa.py
@@ -191,13 +191,14 @@ class TOSASpec:
         tsp_name = op_profile.get("name")
         and_name = op_profile.get("and_name")
         and_name2 = op_profile.get("and_name2")
-        if and_name is not None:
+        if and_name2 is not None:
+            tsp_name = " and ".join(sorted([tsp_name, and_name, and_name2]))
+        elif and_name is not None:
             if and_name < tsp_name:
                 tsp_name = f"{and_name} and {tsp_name}"
             else:
                 tsp_name = f"{tsp_name} and {and_name}"
-        if and_name2 is not None:
-            tsp_name = " and ".join(sorted([tsp_name, and_name, and_name2]))
+
         return tsp_name
 
     def __load_operator(self, op):

--- a/tosa.xml
+++ b/tosa.xml
@@ -47,7 +47,25 @@
     <profile_extension name="EXT-INEXACTROUND" description="Adds inexact rounding support to the RESCALE operator" status="Experimental">
       <profile_supported>PRO-INT</profile_supported>
     </profile_extension>
-    <profile_extension name="EXT-MXFP" description="Microscaling formats" status="Experimental">
+    <profile_extension name="EXT-MX-COMMON" description="Base for MXFP microscaling formats" status="Experimental">
+      <profile_supported>PRO-FP</profile_supported>
+    </profile_extension>
+    <profile_extension name="EXT-MX-FP4E2M1" description="Microscaling format FP4E2M1" status="Experimental">
+      <profile_supported>PRO-FP</profile_supported>
+    </profile_extension>
+    <profile_extension name="EXT-MX-FP6E2M3" description="Microscaling format FP6E2M3" status="Experimental">
+      <profile_supported>PRO-FP</profile_supported>
+    </profile_extension>
+    <profile_extension name="EXT-MX-FP6E3M2" description="Microscaling format FP6E3M2" status="Experimental">
+      <profile_supported>PRO-FP</profile_supported>
+    </profile_extension>
+    <profile_extension name="EXT-MX-FP8E4M3" description="Microscaling format FP8E4M3" status="Experimental">
+      <profile_supported>PRO-FP</profile_supported>
+    </profile_extension>
+    <profile_extension name="EXT-MX-FP8E5M2" description="Microscaling format FP8E5M2" status="Experimental">
+      <profile_supported>PRO-FP</profile_supported>
+    </profile_extension>
+    <profile_extension name="EXT-MX-INT8" description="Microscaling format INT8" status="Experimental">
       <profile_supported>PRO-FP</profile_supported>
     </profile_extension>
     <profile_extension name="EXT-SHAPE" description="Shape calcuation operators" status="Experimental">
@@ -406,19 +424,19 @@
           <type name='out_t' />
         </types>
         <typesupport mode="fp4e2m1 with fp8ue8m0 scale factor" in_t="fp4e2m1_t" scale_t="fp8ue8m0_t" weight_t="fp4e2m1_t" out_t="fp32_t" version_added="1.1">
-          <op_profile name="EXT-MXFP-CONV"/>
+          <op_profile name="EXT-MXFP-CONV" and_name="EXT-MX-FP4E2M1" and_name2="EXT-MX-COMMON"/>
         </typesupport>
         <typesupport mode="fp6e2m3 with fp8ue8m0 scale factor" in_t="fp6e2m3_t" scale_t="fp8ue8m0_t" weight_t="fp6e2m3_t" out_t="fp32_t" version_added="1.1">
-          <op_profile name="EXT-MXFP-CONV"/>
+          <op_profile name="EXT-MXFP-CONV" and_name="EXT-MX-FP6E2M3" and_name2="EXT-MX-COMMON"/>
         </typesupport>
         <typesupport mode="fp6e3m2 with fp8ue8m0 scale factor" in_t="fp6e3m2_t" scale_t="fp8ue8m0_t" weight_t="fp6e3m2_t" out_t="fp32_t" version_added="1.1">
-          <op_profile name="EXT-MXFP-CONV"/>
+          <op_profile name="EXT-MXFP-CONV" and_name="EXT-MX-FP6E3M2" and_name2="EXT-MX-COMMON"/>
         </typesupport>
         <typesupport mode="fp8e4m3 with fp8ue8m0 scale factor" in_t="fp8e4m3_t" scale_t="fp8ue8m0_t" weight_t="fp8e4m3_t" out_t="fp32_t" version_added="1.1">
-          <op_profile name="EXT-MXFP-CONV"/>
+          <op_profile name="EXT-MXFP-CONV" and_name="EXT-MX-FP8E4M3" and_name2="EXT-MX-COMMON"/>
         </typesupport>
         <typesupport mode="fp8e5m2 with fp8ue8m0 scale factor" in_t="fp8e5m2_t" scale_t="fp8ue8m0_t" weight_t="fp8e5m2_t" out_t="fp32_t" version_added="1.1">
-          <op_profile name="EXT-MXFP-CONV"/>
+          <op_profile name="EXT-MXFP-CONV" and_name="EXT-MX-FP8E5M2" and_name2="EXT-MX-COMMON"/>
         </typesupport>
       </operator>
       <operator>
@@ -810,22 +828,22 @@
           <type name='out_t' />
         </types>
         <typesupport mode="Scaled fp4e2m1 with fp8ue8m0 scale and fp32 accumulate" A_t="fp4e2m1_t" B_t="fp4e2m1_t" scale_t="fp8ue8m0_t" out_t="fp32_t" version_added="1.1">
-          <op_profile name="EXT-MXFP"/>
+          <op_profile name="EXT-MX-COMMON" and_name="EXT-MX-FP4E2M1"/>
         </typesupport>
         <typesupport mode="Scaled fp6e2m3 with fp8ue8m0 scale and fp32 accumulate" A_t="fp6e2m3_t" B_t="fp6e2m3_t" scale_t="fp8ue8m0_t" out_t="fp32_t" version_added="1.1">
-          <op_profile name="EXT-MXFP"/>
+          <op_profile name="EXT-MX-COMMON" and_name="EXT-MX-FP6E2M3"/>
         </typesupport>
         <typesupport mode="Scaled fp6e3m2 with fp8ue8m0 scale and fp32 accumulate" A_t="fp6e3m2_t" B_t="fp6e3m2_t" scale_t="fp8ue8m0_t" out_t="fp32_t" version_added="1.1">
-          <op_profile name="EXT-MXFP"/>
+          <op_profile name="EXT-MX-COMMON" and_name="EXT-MX-FP6E3M2"/>
         </typesupport>
         <typesupport mode="Scaled fp8e4m3 with fp8ue8m0 scale and fp32 accumulate" A_t="fp8e4m3_t" B_t="fp8e4m3_t" scale_t="fp8ue8m0_t" out_t="fp32_t" version_added="1.1">
-          <op_profile name="EXT-MXFP"/>
+          <op_profile name="EXT-MX-COMMON" and_name="EXT-MX-FP8E4M3"/>
         </typesupport>
         <typesupport mode="Scaled fp8e5m2 with fp8ue8m0 scale and fp32 accumulate" A_t="fp8e5m2_t" B_t="fp8e5m2_t" scale_t="fp8ue8m0_t" out_t="fp32_t" version_added="1.1">
-          <op_profile name="EXT-MXFP"/>
+          <op_profile name="EXT-MX-COMMON" and_name="EXT-MX-FP8E5M2"/>
         </typesupport>
         <typesupport mode="Scaled mxint8 with fp8ue8m0 scale and fp32 accumulate" A_t="mxint8_t" B_t="mxint8_t" scale_t="fp8ue8m0_t" out_t="fp32_t" version_added="1.1">
-          <op_profile name="EXT-MXFP"/>
+          <op_profile name="EXT-MX-COMMON" and_name="EXT-MX-INT8"/>
         </typesupport>
       </operator>
       <operator>
@@ -3331,40 +3349,40 @@ used.</description>
           <type name='out_t'/>
         </types>
         <typesupport mode="fp4e2m1 with fp8ue8m0 scale to bf16" in_t="fp4e2m1_t" scale_t="fp8ue8m0_t" out_t="bf16_t" version_added="1.1">
-          <op_profile name="EXT-MXFP" and_name="EXT-BF16"/>
+          <op_profile name="EXT-MX-COMMON" and_name="EXT-MX-FP4E2M1" and_name2="EXT-BF16"/>
         </typesupport>
         <typesupport mode="fp6e2m3 with fp8ue8m0 scale to bf16" in_t="fp6e2m3_t" scale_t="fp8ue8m0_t" out_t="bf16_t" version_added="1.1">
-          <op_profile name="EXT-MXFP" and_name="EXT-BF16"/>
+          <op_profile name="EXT-MX-COMMON" and_name="EXT-MX-FP6E2M3" and_name2="EXT-BF16"/>
         </typesupport>
         <typesupport mode="fp6e3m2 with fp8ue8m0 scale to bf16" in_t="fp6e3m2_t" scale_t="fp8ue8m0_t" out_t="bf16_t" version_added="1.1">
-          <op_profile name="EXT-MXFP" and_name="EXT-BF16"/>
+          <op_profile name="EXT-MX-COMMON" and_name="EXT-MX-FP6E3M2" and_name2="EXT-BF16"/>
         </typesupport>
         <typesupport mode="fp8e4m3 with fp8ue8m0 scale to bf16" in_t="fp8e4m3_t" scale_t="fp8ue8m0_t" out_t="bf16_t" version_added="1.1">
-          <op_profile name="EXT-MXFP" and_name="EXT-BF16"/>
+          <op_profile name="EXT-MX-COMMON" and_name="EXT-MX-FP8E4M3" and_name2="EXT-BF16"/>
         </typesupport>
         <typesupport mode="fp8e5m2 with fp8ue8m0 scale to bf16" in_t="fp8e5m2_t" scale_t="fp8ue8m0_t" out_t="bf16_t" version_added="1.1">
-          <op_profile name="EXT-MXFP" and_name="EXT-BF16"/>
+          <op_profile name="EXT-MX-COMMON" and_name="EXT-MX-FP8E5M2" and_name2="EXT-BF16"/>
         </typesupport>
         <typesupport mode="mxint8 with fp8ue8m0 scale to bf16" in_t="mxint8_t" scale_t="fp8ue8m0_t" out_t="bf16_t" version_added="1.1">
-          <op_profile name="EXT-MXFP" and_name="EXT-BF16"/>
+          <op_profile name="EXT-MX-COMMON" and_name="EXT-MX-INT8" and_name2="EXT-BF16"/>
         </typesupport>
         <typesupport mode="fp4e2m1 with fp8ue8m0 scale to fp32" in_t="fp4e2m1_t" scale_t="fp8ue8m0_t" out_t="fp32_t" version_added="1.1">
-          <op_profile name="EXT-MXFP" />
+          <op_profile name="EXT-MX-COMMON" and_name="EXT-MX-FP4E2M1" />
         </typesupport>
         <typesupport mode="fp6e2m3 with fp8ue8m0 scale to fp32" in_t="fp6e2m3_t" scale_t="fp8ue8m0_t" out_t="fp32_t" version_added="1.1">
-          <op_profile name="EXT-MXFP"/>
+          <op_profile name="EXT-MX-COMMON" and_name="EXT-MX-FP6E2M3"/>
         </typesupport>
         <typesupport mode="fp6e3m2 with fp8ue8m0 scale to fp32" in_t="fp6e3m2_t" scale_t="fp8ue8m0_t" out_t="fp32_t" version_added="1.1">
-          <op_profile name="EXT-MXFP"/>
+          <op_profile name="EXT-MX-COMMON" and_name="EXT-MX-FP6E3M2"/>
         </typesupport>
         <typesupport mode="fp8e4m3 with fp8ue8m0 scale to fp32" in_t="fp8e4m3_t" scale_t="fp8ue8m0_t" out_t="fp32_t" version_added="1.1">
-          <op_profile name="EXT-MXFP"/>
+          <op_profile name="EXT-MX-COMMON" and_name="EXT-MX-FP8E4M3"/>
         </typesupport>
         <typesupport mode="fp8e5m2 with fp8ue8m0 scale to fp32" in_t="fp8e5m2_t" scale_t="fp8ue8m0_t" out_t="fp32_t" version_added="1.1">
-          <op_profile name="EXT-MXFP"/>
+          <op_profile name="EXT-MX-COMMON" and_name="EXT-MX-FP8E5M2"/>
         </typesupport>
         <typesupport mode="mxint8 with fp8ue8m0 scale to fp32" in_t="mxint8_t" scale_t="fp8ue8m0_t" out_t="fp32_t" version_added="1.1">
-          <op_profile name="EXT-MXFP"/>
+          <op_profile name="EXT-MX-COMMON" and_name="EXT-MX-INT8"/>
         </typesupport>
       </operator>
       <operator>
@@ -3393,40 +3411,40 @@ used.</description>
           <type name='out_t'/>
         </types>
         <typesupport mode="bf16 to fp4e2m1 with fp8ue8m0 scale" in_t="bf16_t" scale_t="fp8ue8m0_t" out_t="fp4e2m1_t" version_added="1.1">
-          <op_profile name="EXT-MXFP"/>
+          <op_profile name="EXT-MX-COMMON" and_name="EXT-MX-FP4E2M1"/>
         </typesupport>
         <typesupport mode="bf16 to fp6e2m3 with fp8ue8m0 scale" in_t="bf16_t" scale_t="fp8ue8m0_t" out_t="fp6e2m3_t" version_added="1.1">
-          <op_profile name="EXT-MXFP" and_name="EXT-BF16"/>
+          <op_profile name="EXT-MX-COMMON" and_name="EXT-MX-FP6E2M3" and_name2="EXT-BF16"/>
         </typesupport>
         <typesupport mode="bf16 to fp6e3m2 with fp8ue8m0 scale" in_t="bf16_t" scale_t="fp8ue8m0_t" out_t="fp6e3m2_t" version_added="1.1">
-          <op_profile name="EXT-MXFP" and_name="EXT-BF16"/>
+          <op_profile name="EXT-MX-COMMON" and_name="EXT-MX-FP6E3M2" and_name2="EXT-BF16"/>
         </typesupport>
         <typesupport mode="bf16 to fp8e4m3 with fp8ue8m0 scale" in_t="bf16_t" scale_t="fp8ue8m0_t" out_t="fp8e4m3_t" version_added="1.1">
-          <op_profile name="EXT-MXFP" and_name="EXT-BF16"/>
+          <op_profile name="EXT-MX-COMMON" and_name="EXT-MX-FP8E4M3" and_name2="EXT-BF16"/>
         </typesupport>
         <typesupport mode="bf16 to fp8e5m2 with fp8ue8m0 scale" in_t="bf16_t" scale_t="fp8ue8m0_t" out_t="fp8e5m2_t" version_added="1.1">
-          <op_profile name="EXT-MXFP" and_name="EXT-BF16"/>
+          <op_profile name="EXT-MX-COMMON" and_name="EXT-MX-FP8E5M2" and_name2="EXT-BF16"/>
         </typesupport>
         <typesupport mode="bf16 to mxint8 with fp8ue8m0 scale" in_t="bf16_t" scale_t="fp8ue8m0_t" out_t="mxint8_t" version_added="1.1">
-          <op_profile name="EXT-MXFP" and_name="EXT-BF16"/>
+          <op_profile name="EXT-MX-COMMON" and_name="EXT-MX-INT8" and_name2="EXT-BF16"/>
         </typesupport>
         <typesupport mode="fp32 to fp4e2m1 with fp8ue8m0 scale" in_t="fp32_t" scale_t="fp8ue8m0_t" out_t="fp4e2m1_t" version_added="1.1">
-          <op_profile name="EXT-MXFP"/>
+          <op_profile name="EXT-MX-COMMON" and_name="EXT-MX-FP4E2M1"/>
         </typesupport>
         <typesupport mode="fp32 to fp6e2m3 with fp8ue8m0 scale" in_t="fp32_t" scale_t="fp8ue8m0_t" out_t="fp6e2m3_t" version_added="1.1">
-          <op_profile name="EXT-MXFP"/>
+          <op_profile name="EXT-MX-COMMON" and_name="EXT-MX-FP6E2M3"/>
         </typesupport>
         <typesupport mode="fp32 to fp6e3m2 with fp8ue8m0 scale" in_t="fp32_t" scale_t="fp8ue8m0_t" out_t="fp6e3m2_t" version_added="1.1">
-          <op_profile name="EXT-MXFP"/>
+          <op_profile name="EXT-MX-COMMON" and_name="EXT-MX-FP6E3M2"/>
         </typesupport>
         <typesupport mode="fp32 to fp8e4m3 with fp8ue8m0 scale" in_t="fp32_t" scale_t="fp8ue8m0_t" out_t="fp8e4m3_t" version_added="1.1">
-          <op_profile name="EXT-MXFP"/>
+          <op_profile name="EXT-MX-COMMON" and_name="EXT-MX-FP8E4M3"/>
         </typesupport>
         <typesupport mode="fp32 to fp8e5m2 with fp8ue8m0 scale" in_t="fp32_t" scale_t="fp8ue8m0_t" out_t="fp8e5m2_t" version_added="1.1">
-          <op_profile name="EXT-MXFP"/>
+          <op_profile name="EXT-MX-COMMON" and_name="EXT-MX-FP8E5M2"/>
         </typesupport>
         <typesupport mode="fp32 to mxint8 with fp8ue8m0 scale" in_t="fp32_t" scale_t="fp8ue8m0_t" out_t="mxint8_t" version_added="1.1">
-          <op_profile name="EXT-MXFP"/>
+          <op_profile name="EXT-MX-COMMON" and_name="EXT-MX-INT8"/>
         </typesupport>
       </operator>
       <operator>
@@ -3600,19 +3618,19 @@ used.</description>
           <op_profile name="PRO-FP"/>
         </typesupport>
         <typesupport mode="fp8ue8m0" out_t="fp8ue8m0_t"  version_added="1.1">
-          <op_profile name="EXT-MXFP"/>
+          <op_profile name="EXT-MX-COMMON"/>
         </typesupport>
         <typesupport mode="fp6e3m2" out_t="fp6e3m2_t"  version_added="1.1">
-          <op_profile name="EXT-MXFP"/>
+          <op_profile name="EXT-MX-FP6E3M2"/>
         </typesupport>
         <typesupport mode="fp6e2m3" out_t="fp6e2m3_t"  version_added="1.1">
-          <op_profile name="EXT-MXFP"/>
+          <op_profile name="EXT-MX-FP6E2M3"/>
         </typesupport>
         <typesupport mode="fp4e2m1" out_t="fp4e2m1_t"  version_added="1.1">
-          <op_profile name="EXT-MXFP"/>
+          <op_profile name="EXT-MX-FP4E2M1"/>
         </typesupport>
         <typesupport mode="mxint8" out_t="mxint8_t"  version_added="1.1">
-          <op_profile name="EXT-MXFP"/>
+          <op_profile name="EXT-MX-INT8"/>
         </typesupport>
       </operator>
       <operator>
@@ -3988,19 +4006,19 @@ used.</description>
           <op_profile name="PRO-FP" and_name="EXT-SHAPE"/>
         </typesupport>
         <typesupport mode="fp6e3m2" in_t="fp6e3m2_t" version_added="1.1">
-          <op_profile name="EXT-MXFP" and_name="EXT-SHAPE"/>
+          <op_profile name="EXT-MX-FP6E3M2" and_name="EXT-SHAPE"/>
         </typesupport>
         <typesupport mode="fp6e2m3" in_t="fp6e2m3_t" version_added="1.1">
-          <op_profile name="EXT-MXFP" and_name="EXT-SHAPE"/>
+          <op_profile name="EXT-MX-FP6E2M3" and_name="EXT-SHAPE"/>
         </typesupport>
         <typesupport mode="fp4e2m1" in_t="fp4e2m1_t" version_added="1.1">
-          <op_profile name="EXT-MXFP" and_name="EXT-SHAPE"/>
+          <op_profile name="EXT-MX-FP4E2M1" and_name="EXT-SHAPE"/>
         </typesupport>
         <typesupport mode="mxint8" in_t="mxint8_t" version_added="1.1">
-          <op_profile name="EXT-MXFP" and_name="EXT-SHAPE"/>
+          <op_profile name="EXT-MX-INT8" and_name="EXT-SHAPE"/>
         </typesupport>
         <typesupport mode="fp8ue8m0" in_t="fp8ue8m0_t" version_added="1.1">
-          <op_profile name="EXT-MXFP" and_name="EXT-SHAPE"/>
+          <op_profile name="EXT-MX-COMMON" and_name="EXT-SHAPE"/>
         </typesupport>
         <typesupport mode="i64" in_t="i64_t" version_added="1.1">
           <op_profile name="EXT-INT64" and_name="EXT-SHAPE"/>
@@ -4355,7 +4373,7 @@ used.</description>
  </enum>
 
 <enum name="block_size_t" description="Block size for the block_scaled formats">
-  <enumval value="32" name="BLOCK_SIZE_32" description="Block size of 32" extension="EXT-MXFP"/>
+  <enumval value="32" name="BLOCK_SIZE_32" description="Block size of 32" extension="EXT-MX-COMMON"/>
 </enum>
 
 </tosa>

--- a/tosa.xsd
+++ b/tosa.xsd
@@ -28,7 +28,13 @@
     <xs:enumeration value="EXT-DYNAMIC"/>
     <xs:enumeration value="EXT-DOUBLEROUND"/>
     <xs:enumeration value="EXT-INEXACTROUND"/>
-    <xs:enumeration value="EXT-MXFP"/>
+    <xs:enumeration value="EXT-MX-COMMON"/>
+    <xs:enumeration value="EXT-MX-FP4E2M1"/>
+    <xs:enumeration value="EXT-MX-FP6E2M3"/>
+    <xs:enumeration value="EXT-MX-FP6E3M2"/>
+    <xs:enumeration value="EXT-MX-FP8E4M3"/>
+    <xs:enumeration value="EXT-MX-FP8E5M2"/>
+    <xs:enumeration value="EXT-MX-INT8"/>
     <xs:enumeration value="EXT-MXFP-CONV"/>
   </xs:restriction>
 </xs:simpleType>


### PR DESCRIPTION
Allow implementations to choose which of the concrete MX formats that it wishes to implement by supporting individual extensions for each format. EXT-MX-COMMON supports the fp8e8m0 scale factor and 32 element block size.


Change-Id: Iaae3dd0e25ed9c018a8b18a1f5cecec7fac6f960