### PR TITLE
Change size and start arguments for SLICE_SHAPE to tensors

### DIFF
--- a/pseudocode/operators/SLICE_SHAPE.tosac
+++ b/pseudocode/operators/SLICE_SHAPE.tosac
@@ -7,10 +7,13 @@
 // copies and copies may only be made to the extent permitted
 // by a licensing agreement from ARM Limited.
 
-ERROR_IF(size <= 0);
-ERROR_IF(start < 0);
-ERROR_IF(start + size > length(input))
+int32_t size_value = static_cast<int32_t>(tensor_read<i32_t>(size, [1], [0]));
+int32_t start_value = static_cast<int32_t>(tensor_read<i32_t>(start, [1], [0]));
 
-for(int32_t index=0; index < size; index++) {
-    output[index] = input[index + start];
+ERROR_IF(size_value <= 0);
+ERROR_IF(start_value < 0);
+ERROR_IF(start_value + size_value > length(input))
+
+for(int32_t index=0; index < size_value; index++) {
+    output[index] = input[index + start_value];
 }

--- a/tosa.xml
+++ b/tosa.xml
@@ -4474,15 +4474,17 @@ used.</description>
               <op_profile name="PRO-FP"/>
             </ctc>
           </argument>
-          <argument category="input" name="start" type="i32_t" shape="-" tensor-element-type="-">
+          <argument category="input" name="start" type="tensor_t" shape="[1]" tensor-element-type="i32_t">
             <description>First location within input to include</description>
+            <rank min="1" max="1"/>
             <ctc>
               <op_profile name="PRO-INT"/>
               <op_profile name="PRO-FP"/>
             </ctc>
           </argument>
-          <argument category="input" name="size" type="i32_t" shape="-" tensor-element-type="-">
+          <argument category="input" name="size" type="tensor_t" shape="[1]" tensor-element-type="i32_t">
             <description>Number of dimensions from input to include in the output</description>
+            <rank min="1" max="1"/>
             <ctc>
               <op_profile name="PRO-INT"/>
               <op_profile name="PRO-FP"/>


### PR DESCRIPTION
The type for inputs is always a tensor type, even in these instances where it is a single value.


Change-Id: Ifffac7c8fbaedc6723a078f4043f0faf7ac2723c