### PR TITLE
Fix CONV2D_BLOCK_SCALED scale_input value

### DIFF
--- a/pseudocode/operators/CONV2D_BLOCK_SCALED.tosac
+++ b/pseudocode/operators/CONV2D_BLOCK_SCALED.tosac
@@ -28,7 +28,8 @@ for_each(0 <= n < N, 0 <= oy < OH, 0 <= ox < OW, 0 <= oc < OC) {
             out_t block_acc = 0;
 
             // Read the scales for this block
-            out_t scale_input = static_cast<out_t>(tensor_read<scale_t>(input_scale, [N,IH,IW,IC/block_size], [n,iy,ix,b]));
+            out_t scale_input = (0 <= y < IH && 0 <= x < IW) ?
+                static_cast<out_t>(tensor_read<scale_t>(input_scale, [N,IH,IW,IC/block_size], [n,y,x,b])) : 1;
             out_t scale_weight = static_cast<out_t>(tensor_read<scale_t>(weight_scale, [OC,KH,KW,IC/block_size], [oc,ky,kx,b]));
 
             for_each(0 <= i < block_size) {


### PR DESCRIPTION
Change to use y and x instead of iy and ix and only read scale_input when it is within the data range.

Change-Id: I93917b5e357620d760ca5f43ba442c5e11ae06c1