### PR TITLE
Add require check for out of range index output in ARGMAX

### DIFF
--- a/pseudocode/operators/ARGMAX.tosac
+++ b/pseudocode/operators/ARGMAX.tosac
@@ -37,6 +37,7 @@ for_each_data_position(left_index in left_shape) {
                 }
             }
         }
+        REQUIRE(max_index <= maximum<out_t>());
         shape_t index = flatten(left_index, right_index);
         tensor_write<out_t>(output, shape, index, max_index);
     }

--- a/pseudocode/operators/ARGMAX.tosac
+++ b/pseudocode/operators/ARGMAX.tosac
@@ -1,7 +1,7 @@
 //
 // This confidential and proprietary software may be used only as
 // authorised by a licensing agreement from ARM Limited
-// (C) COPYRIGHT 2020-2024 ARM Limited
+// (C) COPYRIGHT 2020-2024,2026 ARM Limited
 // ALL RIGHTS RESERVED
 // The entire notice above must be reproduced on all authorised
 // copies and copies may only be made to the extent permitted
@@ -33,11 +33,11 @@ for_each_data_position(left_index in left_shape) {
             if (result != max_value) {
                 if (!(isNaN(result) && isNaN(max_value))) {
                     max_value = result;
+                    REQUIRE(i <= maximum<out_t>());
                     max_index = i;
                 }
             }
         }
-        REQUIRE(max_index <= maximum<out_t>());
         shape_t index = flatten(left_index, right_index);
         tensor_write<out_t>(output, shape, index, max_index);
     }


### PR DESCRIPTION
ARGMAX currently requires an i32_t output that indicates the
location of a value in the input tensor. However, under the
level `tosa_level_none`, the value of `tensor_size_t` can
exceed the range allowed by i32_t. As a result, this could
lead to undefined behaviour if the max value in the input is
located at an index > i32_t.

An example of a problematic case would look like:
`ARGMAX(TENSOR(shape=[9123372036854775808], dtype=f32), axis=0)`

This commit adds a REQUIRE condition to check this case.

Signed-off-by: Luke Hutton <luke.hutton@arm.com>