### PR TITLE
Fix conversion to block scaled calculation

### DIFF
--- a/pseudocode/library/numeric_conversion_helpers.tosac
+++ b/pseudocode/library/numeric_conversion_helpers.tosac
@@ -1,7 +1,7 @@
 //
 // This confidential and proprietary software may be used only as
 // authorised by a licensing agreement from ARM Limited
-// (C) COPYRIGHT 2020-2025 ARM Limited
+// (C) COPYRIGHT 2020-2026 ARM Limited
 // ALL RIGHTS RESERVED
 // The entire notice above must be reproduced on all authorised
 // copies and copies may only be made to the extent permitted
@@ -62,6 +62,13 @@ out_t zero_extend<out_t>(in_t input);
 // Nop for floating-point types
 out_t truncate(in_t input);
 
+// Return the largest value such that all smaller magnitude values will round without overflow
+float_t get_largest_value_rounding_to_normal_max<in_t>() {
+    float_t max_value = normal_max<in_t>();
+    float_t max_ulp = is_same<in_t,mxint8_t>() ? 1/64.0 : exp2(ilog2(max_value) - normal_frac<in_t>());
+    return max_value + 0.5*max_ulp;
+}
+
 scale_t calc_block_scale<in_t, scale_t, out_t>(in_t max_abs) {
   if (max_abs == 0) {
     return normal_min<scale_t>();
@@ -69,7 +76,7 @@ scale_t calc_block_scale<in_t, scale_t, out_t>(in_t max_abs) {
     return NaN;
   }
 
-  in_t out_max = static_cast<in_t>(normal_max<out_t>());
+  in_t out_max = get_largest_value_rounding_to_normal_max<out_t>();
   fp64_t scale_exp = is_same<out_t, fp8e4m3_t>() ?
       ceil(log2(max_abs / out_max)) :
       floor(log2(max_abs / out_max)) + 1;


### PR DESCRIPTION
When calculating the block scale, the denominator
is set to the largest value for which the rounded
block scaled conversion does not overflow.
