### PR TITLE
Clarify purity of operations

### DIFF
--- a/chapters/introduction.adoc
+++ b/chapters/introduction.adoc
@@ -1,7 +1,7 @@
 //
 // This confidential and proprietary software may be used only as
 // authorised by a licensing agreement from ARM Limited
-// (C) COPYRIGHT 2020-2025 ARM Limited
+// (C) COPYRIGHT 2020-2026 ARM Limited
 // ALL RIGHTS RESERVED
 // The entire notice above must be reproduced on all authorised
 // copies and copies may only be made to the extent permitted
@@ -397,7 +397,7 @@ The conformance tests are not exhaustive, so an implementation that passes the c
 
 The <<Operator Graphs>> section of this specification defines a TOSA graph and the behavior defined for a TOSA graph.
 This behavior is captured in the pseudocode function tosa_execute_graph().
-For a given input graph (with attributes) and input tensors there are three possible tosa_graph_result values after executing the graph:
+For a given input graph (with attributes) and input tensors there are three possible graph_result values after executing the graph:
 
 * tosa_unpredictable: The result of the graph on the given inputs cannot be relied upon.
 * tosa_error: The graph does not meet the specification and is recognised as an illegal graph.
@@ -405,7 +405,7 @@ For a given input graph (with attributes) and input tensors there are three poss
 
 An implementation must behave as follows given the above tosa_graph result values:
 
-* For tosa_unpredictable, the implementation can return whatever result it chooses (including error)
+* For tosa_unpredictable, the implementation can return whatever result it chooses (including error), but must not write outside the bounds of any tensors involved in execution.
 * For tosa_error, the implementation must return an error result (and there is no requirement on how much of the graph is executed, if any).
 * For tosa_valid, the implementation must execute the entire graph without error and return the result defined by this specification.
 
@@ -413,23 +413,24 @@ In terms of pseudocode, if *graph* is a TOSA graph consisting of TOSA operators 
 
 [source,c++]
 ----
-// Global result status value
-// Will be updated by REQUIRE and ERROR_IF statements when evaluating the TOSA graph
-tosa_result_t tosa_graph_result;
 // Tracks the nesting depth of TOSA operators to allow a limit on nesting depth to be checked.
 int32_t tosa_nesting_depth;
 
 bool_t tosa_test_compliance(tosa_graph_t graph, tensor_list_t input_list, tosa_level_t level) {
     shape_list_t output_list_spec = tosa_allocate_list(tosa_output_shape(graph));
     shape_list_t output_list_test = tosa_allocate_list(tosa_output_shape(graph));
-    tosa_graph_result = tosa_valid;    // result starts as valid
     tosa_nesting_depth = 0;            // if/while nesting level
-    tosa_execute_graph(graph, input_list, output_list_spec, level);
-    if (tosa_graph_result == tosa_unpredictable) {
+
+    // Result status value
+    // REQUIRE and ERROR_IF statements update the graph result value
+    tosa_result_t graph_result = tosa_valid;
+
+    graph_result = tosa_execute_graph(graph, input_list, output_list_spec, level, graph_result);
+    if (graph_result == tosa_unpredictable) {
         return true;    // No requirement to match an unpredictable result
     }
     result_test = execute_implementation_under_test(graph, input_list, output_list_test);
-    if (tosa_graph_result == tosa_error) {
+    if (graph_result == tosa_error) {
         return result_test == tosa_error;   // result must be an error
     }
     if (exact_tensor_match(output_list_spec, output_list_test)) {

--- a/chapters/operators.adoc
+++ b/chapters/operators.adoc
@@ -1,7 +1,7 @@
 //
 // This confidential and proprietary software may be used only as
 // authorised by a licensing agreement from ARM Limited
-// (C) COPYRIGHT 2020-2021,2024 ARM Limited
+// (C) COPYRIGHT 2020-2021,2024,2026 ARM Limited
 // ALL RIGHTS RESERVED
 // The entire notice above must be reproduced on all authorised
 // copies and copies may only be made to the extent permitted
@@ -25,6 +25,7 @@ Arguments belong to one of three categories: Input, Output, or Attribute. The ca
 * An Input argument must be a tensor or a list of tensors used to provide the data read by the operation.
 * An Attribute argument is constant, its value is always known at compilation time.
 * An Output argument must be a tensor or a list of tensors into which the data produced by the operation is written.
+** The shape of each output argument must be derivable from operator input arguments and attributes so that the required output storage is known before execution.
 
 Profiles may restrict a set of inputs and/or outputs to be known (constant) at compile time.
 Compile time is defined as the time at which TOSA operators are converted to implementation specific commands prior to execution.
@@ -74,7 +75,7 @@ implementation-defined order that must be a topological ordering of the TOSA gra
 
 [source,c++]
 ----
-tosa_execute_graph(tosa_context_t context, tosa_graph_t graph, tensor_list_t input_list, tensor_list_t output_list, tosa_level_t level) {
+tosa_result_t tosa_execute_graph(tosa_context_t context, tosa_graph_t graph, tensor_list_t input_list, tensor_list_t output_list, tosa_level_t level, tosa_result_t graph_result) {
     ERROR_IF(tensor_list_shape(input_list) != tosa_input_shape(graph));
     ERROR_IF(tensor_list_shape(output_list) != tosa_output_shape(graph));
 
@@ -93,8 +94,10 @@ tosa_execute_graph(tosa_context_t context, tosa_graph_t graph, tensor_list_t inp
         ERROR_IF(operator output tensors do not meet requirement of operator Arguments outputs)
         ERROR_IF(operator data types do not meet requirement of operator Supported Data Types)
         // Execute the operator as defined by the operation function pseduo-code
-        tosa_execute_operator(context, operator, level);
+        graph_result = tosa_execute_operator(context, operator, level, graph_result);
     }
+
+    return graph_result;
 }
 ----
 

--- a/chapters/pseudocode.adoc
+++ b/chapters/pseudocode.adoc
@@ -1,7 +1,7 @@
 //
 // This confidential and proprietary software may be used only as
 // authorised by a licensing agreement from ARM Limited
-// (C) COPYRIGHT 2021-2025 ARM Limited
+// (C) COPYRIGHT 2021-2026 ARM Limited
 // ALL RIGHTS RESERVED
 // The entire notice above must be reproduced on all authorised
 // copies and copies may only be made to the extent permitted
@@ -59,7 +59,7 @@ The following functions are used to define the valid conditions for TOSA operato
 
 The REQUIRE function defines the conditions required by the TOSA operator.
 If the conditions are not met then the result of the TOSA graph is marked as unpredictable.
-Once the tosa_graph_result is set to tosa_unpredictable, the whole graph is considered unpredictable.
+Once the graph_result is set to tosa_unpredictable, the whole graph is considered unpredictable.
 
 The ERROR_IF function defines a condition that must set an error if the condition holds and the graph is not unpredictable.
 Note that if a graph contains both unpredictable and error statements then result of tosa_execute_graph() is tosa_unpredictable.
@@ -74,25 +74,36 @@ This condition is captured in the ERROR_IF function.
 
 [source,c++]
 ----
-void REQUIRE(condition) {
+define REQUIRE(condition) \
+    graph_result = REQUIRE_IMPL(condition, graph_result);
+
+tosa_result_t REQUIRE_IMPL(condition, tosa_result_t graph_result) {
     // Unpredictable overrides any previous result
     if (!(condition)) {
-        tosa_graph_result = tosa_unpredictable;
+        graph_result = tosa_unpredictable;
     }
+    return graph_result;
 }
 
-void ERROR_IF(condition) {
+define ERROR_IF(condition) \
+    graph_result = ERROR_IF_IMPL(condition, graph_result);
+
+tosa_result_t ERROR_IF_IMPL(condition, tosa_result_t graph_result) {
     // Error encodes a predictable error state and so is not registered
     // if the graph is marked as unpredictable.
-    if (tosa_graph_result != tosa_unpredictable && condition) {
-        tosa_graph_result = tosa_error;
+    if (graph_result != tosa_unpredictable && condition) {
+        graph_result = tosa_error;
     }
+    return graph_result;
 }
 
-void LEVEL_CHECK(condition) {
+define LEVEL_CHECK(condition) \
+    graph_result = LEVEL_CHECK_IMPL(condition, graph_result);
+
+tosa_result_t LEVEL_CHECK_IMPL(condition, tosa_result_t graph_result) {
     // If a level is specified and the level condition fails then
     // the result is unpredictable.
-    REQUIRE(condition);
+    return REQUIRE_IMPL(condition, graph_result);
 }
 ----
 

--- a/pseudocode/operators/COND_IF.tosac
+++ b/pseudocode/operators/COND_IF.tosac
@@ -1,7 +1,7 @@
 //
 // This confidential and proprietary software may be used only as
 // authorised by a licensing agreement from ARM Limited
-// (C) COPYRIGHT 2020-2024 ARM Limited
+// (C) COPYRIGHT 2020-2024,2026 ARM Limited
 // ALL RIGHTS RESERVED
 // The entire notice above must be reproduced on all authorised
 // copies and copies may only be made to the extent permitted
@@ -16,8 +16,8 @@ ERROR_IF(tensor_size(shape) != 1);
 
 tosa_nesting_depth++;
 if (condition[0]) {
-    tosa_execute_graph(then_graph, input_list, output_list);
+    graph_result = tosa_execute_graph(then_graph, input_list, output_list, level, graph_result);
 } else {
-    tosa_execute_graph(else_graph, input_list, output_list);
+    graph_result = tosa_execute_graph(else_graph, input_list, output_list, level, graph_result);
 }
 tosa_nesting_depth--;

--- a/pseudocode/operators/WHILE_LOOP.tosac
+++ b/pseudocode/operators/WHILE_LOOP.tosac
@@ -1,7 +1,7 @@
 //
 // This confidential and proprietary software may be used only as
 // authorised by a licensing agreement from ARM Limited
-// (C) COPYRIGHT 2020-2024 ARM Limited
+// (C) COPYRIGHT 2020-2024,2026 ARM Limited
 // ALL RIGHTS RESERVED
 // The entire notice above must be reproduced on all authorised
 // copies and copies may only be made to the extent permitted
@@ -23,11 +23,11 @@ tensor_list_t list[];    // array of tensor lists indexed by iteration
 bool_t *condition[];     // array of condition tensors indexed by iteration
 list[i] = input_list;    // copy input data as list[0]
 tosa_nesting_depth++;
-tosa_execute_graph(cond_graph, list[i], [ condition[i] ]);   // initial condition
+graph_result = tosa_execute_graph(cond_graph, list[i], [ condition[i] ], level, graph_result);   // initial condition
 while (condition[i][0]) {
-    tosa_execute_graph(body_graph, list[i], list[i+1]);
+    graph_result = tosa_execute_graph(body_graph, list[i], list[i+1], level, graph_result);
     i = i+1;
-    tosa_execute_graph(cond_graph, list[i], [ condition[i] ]);
+    graph_result = tosa_execute_graph(cond_graph, list[i], [ condition[i] ], level, graph_result);
 }
 tosa_nesting_depth--;
 output_list = list[i];


### PR DESCRIPTION
Addresses two aspects of the specification which could hinder intepretation of operation purity of the majority of operations.

1. The specification doesn't currently provide a function that defines what the output shape of an operation should be given the inputs and attributes. This commit adds a line which indicates the presence of one, without explicitly defining it for each operation. The intention here is to express that out-of-bounds writes are not allowed, even in ERROR_IF or REQUIRE cases.

To restrict out of bound writes further, it is stated that an implementation must not write out of bounds when execution is in an unpredictable state.

2. `tosa_graph_result` was previously modelled as a global variable outside of the execution state. It is now modelled as a caller-local execution state. The intent is to clarify that updating `graph_result` is not modifying a global value in memory.

In both cases this helps to determine operations memory side-effect free.

This change also adds some missing parameters to `tosa_execute_graph` which were presumably missing due to typos.