### PR TITLE
Fix ROW_GATHER_BLOCK_SCALED bounds and row_count check

### DIFF
--- a/pseudocode/operators/ROW_GATHER_BLOCK_SCALED.tosac
+++ b/pseudocode/operators/ROW_GATHER_BLOCK_SCALED.tosac
@@ -19,9 +19,11 @@ ERROR_IF((values_len == 1) && (block_size != 1));
 // block-scaled must NOT use block_size=1
 ERROR_IF((values_len == 2) && (block_size == 1));
 
+ERROR_IF(row_count < 1);
+
 for_each(0 <= n < N, 0 <= w < W, 0 <= c < C) {
     index_t k = tensor_read<index_t>(indices, [N, W], [n, w]);
-    REQUIRE(0 <= k && (k+row_count) < K);
+    REQUIRE(0 <= k && (k+row_count) <= K);
 
     for(0 <= r < row_count) {
       in_out_t value = tensor_read<in_out_t>(values[0], [N, K, C], [n, k+r, c]);
@@ -32,7 +34,7 @@ for_each(0 <= n < N, 0 <= w < W, 0 <= c < C) {
 if(values_len == 2) {
     for_each(0 <= n < N, 0 <= w < W, 0 <= c < C/block_size) {
         index_t k = tensor_read<index_t>(indices, [N, W], [n, w]);
-        REQUIRE(0 <= k && (k+row_count) < K);
+        REQUIRE(0 <= k && (k+row_count) <= K);
 
         for(0 <= r < row_count) {
             scale_t value = tensor_read<scale_t>(values[1], [N, K, C/block_size], [n, k+r, c]);


### PR DESCRIPTION
The pseudocode used (k + row_count) < K, which incorrectly rejects valid accesses to the last row. The operator reads rows k through k + row_count - 1, so the correct in-bounds condition is (k + row_count) <= K.

Change-Id: If9adb22bbac4240d68ea279a3f121335ffe538e4
Signed-off-by: Peng Sun <peng.sun@arm.com>