### PR TITLE
Fix clipping for dot product bounds calculation

### DIFF
--- a/pseudocode/library/tosa_reference_check_dotproduct.tosac
+++ b/pseudocode/library/tosa_reference_check_dotproduct.tosac
@@ -1,7 +1,7 @@
 //
 // This confidential and proprietary software may be used only as
 // authorised by a licensing agreement from ARM Limited
-// (C) COPYRIGHT 2024-2025 ARM Limited
+// (C) COPYRIGHT 2024-2026 ARM Limited
 // ALL RIGHTS RESERVED
 // The entire notice above must be reproduced on all authorised
 // copies and copies may only be made to the extent permitted
@@ -13,9 +13,9 @@ bool_t tosa_reference_check_dotproduct<OP, in_t, weight_t, out_t, acc_t>(
     T<weight_t> weight,  // weight tensor
     T<out_t> bias        // bias tensor
 ) {
-    T<in_t>     input_abs  = apply_max_s<in_t>(abs(input),      normal_min<in_t>()); // Element-wise
-    T<weight_t> weight_abs = apply_max_s<weight_t>(abs(weight), normal_min<in_t>()); // Element-wise
-    T<out_t>    bias_abs   = apply_max_s<out_t>(abs(bias),      normal_min<in_t>()); // Element-wise
+    T<in_t>     input_abs  = apply_max_s<in_t>(abs(input),      normal_min<in_t>());     // Element-wise
+    T<weight_t> weight_abs = apply_max_s<weight_t>(abs(weight), normal_min<weight_t>()); // Element-wise
+    T<out_t>    bias_abs   = apply_max_s<out_t>(abs(bias),      normal_min<out_t>());    // Element-wise
     if (!local_bound) {
         in_t input_abs_max = max_value(input_abs);  // maximum over all elements
         for_each_data_position(index in shape(input_abs)) {


### PR DESCRIPTION
Change the dot product bounds calculation to use the correct type for each of the inputs to the operator. Before, `normal_min<in_t>` was used throughout.


Change-Id: I075f0a6bc3672f9214054754b16f8fe97fbd1057