### PR TITLE
Add block_scale_t, set-notation and MATMUL_T Operator

### DIFF
--- a/chapters/appendix_a.adoc
+++ b/chapters/appendix_a.adoc
@@ -1,7 +1,7 @@
 //
 // This confidential and proprietary software may be used only as
 // authorised by a licensing agreement from ARM Limited
-// (C) COPYRIGHT 2023 ARM Limited
+// (C) COPYRIGHT 2023-2024,2026 ARM Limited
 // ALL RIGHTS RESERVED
 // The entire notice above must be reproduced on all authorised
 // copies and copies may only be made to the extent permitted
@@ -243,6 +243,25 @@ for (0 <= n < N, 0 <= y < H, 0 <= c < C) {
 for (0 <= n < N, 0 <= c < C, 0 <= x < W) {
   B[n, c, x] = tosa_pro_fp_data(S, KS, 1, c, (n*C+c)*W+x);
 }
+----
+
+==== MATMUL_T
+
+The following generates input test data for test set S.
+For compliant implementation, the test must pass whenever the attributes satisfy:
+`N*H*W >= MIN_DOT_PRODUCTS`
+
+[source,c++]
+----
+KS = C;
+for (0 <= n < N, 0 <= y < H, 0 <= c < C) {
+  A[n, y, c] = tosa_pro_fp_data(S, KS, 0, c, (n*H+y)*C+c);
+}
+// CAST_TO_BLOCK_SCALED(A) if required
+for (0 <= d < D, 0 <= x < W, 0 <= c < C) {
+  B[d, x, c] = tosa_pro_fp_data(S, KS, 1, c, (d*W+x)*C+c);
+}
+// CAST_TO_BLOCK_SCALED(B) if required
 ----
 
 ==== MATMUL_T_BLOCK_SCALED

--- a/chapters/changes.adoc
+++ b/chapters/changes.adoc
@@ -1,7 +1,7 @@
 //
 // This confidential and proprietary software may be used only as
 // authorised by a licensing agreement from ARM Limited
-// (C) COPYRIGHT 2025 ARM Limited
+// (C) COPYRIGHT 2025-2026 ARM Limited
 // ALL RIGHTS RESERVED
 // The entire notice above must be reproduced on all authorised
 // copies and copies may only be made to the extent permitted
@@ -13,3 +13,4 @@
 
 * Allow mixed fp8e4m3 * fp8e5m2 operation for the MATMUL operator.
 * Add support for fp32 accumulators with the fp8 input types for the MATMUL operator.
+* Add the MATMUL_T operator.

--- a/chapters/introduction.adoc
+++ b/chapters/introduction.adoc
@@ -376,6 +376,15 @@ Signed zero must be supported.
 | -2
 | +1 + 63/64
 | 8-bit integer format with an implicit 1/64 scale defined by <<OCP-MX,OCP-MX>>. +
+
+|block_scale_t<block_size_t block_size, scale_t, value_t>.
+|-
+|-
+| Block scaled type. +
+This does not specify an implementation type. +
+A tensor of this type is a tensor which has block-scaled quantization applied. +
+The type is made up of 3 components: block_size_t, scale_t, value_t. +
+Each of these types will be made evident in an Operator where they are used.
 |===
 
 Note: In this specification, minimum<type> and maximum<type> will denote the minimum and maximum values of the data as stored in memory (ignoring the zero point).
@@ -384,6 +393,105 @@ The minimum and maximum values for each type are given in the preceding table.
 Note: Integer number formats smaller than 8 bits may be used provided that the numerical result is the same as using a sequence of 8-bit TOSA operations.
 For example, the result of a convolution with low precision data must equal that of running the convolution at 8 bits and then clipping the result to the permitted output range.
 This ensures that an Integer profile TOSA implementation can calculate the same result.
+
+.Supported Number Format Sets
+[cols="1,2,2,2,3,5"]
+|===
+|Set|Template|Allowed block_size_t|Allowed scale_t|Allowed value_t|Resulting block scaled data types
+
+|bs32_fp8ue8m0_set_t
+|`block_scale_t<block_size_t block_size, scale_t, value_t>`
+|`BLOCK_SIZE_32`
+|`fp8ue8m0_t`
+|`fp8e4m3_t`, `fp8e5m2_t`, `fp6e3m2_t`, `fp6e2m3_t`, `fp4e2m1_t`, `mxint8_t`
+|A new data type is formed by instantiating the template with an allowed choice of `block_size_t`, `scale_t`, and `value_t`. +
+The resulting data type is named `bs<block size>_<scale type>_<value type>_t` where block size is the integer block size, scale type is scale_t without the _t suffix, and value type is the value_t without the _t suffix. +
+The set of allowed block scaled data types is: +
+`bs32_fp8ue8m0_fp8e4m3_t`, +
+`bs32_fp8ue8m0_fp8e5m2_t`, +
+`bs32_fp8ue8m0_fp6e3m2_t`, +
+`bs32_fp8ue8m0_fp6e2m3_t`, +
+`bs32_fp8ue8m0_fp4e2m1_t`, +
+`bs32_fp8ue8m0_mxint8_t`.
+|===
+
+==== Extension Data Type Mapping
+
+`DEDUCE-EXT` is a marker used in Supported Data Types tables when the required
+extension set is deduced from the concrete input and output data types.
+The following table lists data types introduced by TOSA extensions and the
+extension set deduced for each data type.
+
+.Extension Data Type Mapping
+[width=99]
+|===
+|Data type |Deduced extension(s)
+
+|i64_t
+|EXT-INT64
+
+|i16_t
+|EXT-INT16
+
+|i4_t
+|EXT-INT4
+
+|bf16_t
+|EXT-BF16
+
+|fp8e4m3_t
+|EXT-FP8E4M3
+
+|fp8e5m2_t
+|EXT-FP8E5M2
+
+|fp8ue8m0_t
+|EXT-MX-COMMON
+
+|fp4e2m1_t
+|EXT-MX-FP4E2M1
+
+|fp6e2m3_t
+|EXT-MX-FP6E2M3
+
+|fp6e3m2_t
+|EXT-MX-FP6E3M2
+
+|mxint8_t
+|EXT-MX-INT8
+|===
+
+The following table lists the composite block-scaled data types derived from the supported number format sets.
+
+.Composite Block-Scaled Type Mapping
+[width=99]
+|===
+|Composite data type |Template instantiation |Deduced extension(s)
+
+|bs32_fp8ue8m0_fp8e4m3_t
+|`block_scale_t<BLOCK_SIZE_32, fp8ue8m0_t, fp8e4m3_t>`
+|EXT-MX-COMMON and EXT-MX-FP8E4M3
+
+|bs32_fp8ue8m0_fp8e5m2_t
+|`block_scale_t<BLOCK_SIZE_32, fp8ue8m0_t, fp8e5m2_t>`
+|EXT-MX-COMMON and EXT-MX-FP8E5M2
+
+|bs32_fp8ue8m0_fp6e3m2_t
+|`block_scale_t<BLOCK_SIZE_32, fp8ue8m0_t, fp6e3m2_t>`
+|EXT-MX-COMMON and EXT-MX-FP6E3M2
+
+|bs32_fp8ue8m0_fp6e2m3_t
+|`block_scale_t<BLOCK_SIZE_32, fp8ue8m0_t, fp6e2m3_t>`
+|EXT-MX-COMMON and EXT-MX-FP6E2M3
+
+|bs32_fp8ue8m0_fp4e2m1_t
+|`block_scale_t<BLOCK_SIZE_32, fp8ue8m0_t, fp4e2m1_t>`
+|EXT-MX-COMMON and EXT-MX-FP4E2M1
+
+|bs32_fp8ue8m0_mxint8_t
+|`block_scale_t<BLOCK_SIZE_32, fp8ue8m0_t, mxint8_t>`
+|EXT-MX-COMMON and EXT-MX-INT8
+|===
 
 === Compliance
 

--- a/chapters/tensor_ops.adoc
+++ b/chapters/tensor_ops.adoc
@@ -1,7 +1,7 @@
 //
 // This confidential and proprietary software may be used only as
 // authorised by a licensing agreement from ARM Limited
-// (C) COPYRIGHT 2020-2025 ARM Limited
+// (C) COPYRIGHT 2020-2026 ARM Limited
 // ALL RIGHTS RESERVED
 // The entire notice above must be reproduced on all authorised
 // copies and copies may only be made to the extent permitted
@@ -231,7 +231,32 @@ include::{generated}/operators/MATMUL.adoc[]
 include::{pseudocode}/operators/MATMUL.tosac[lines=10..-1]
 ----
 
-==== MATMUL_T_BLOCK_SCALED
+==== MATMUL_T
+
+Performs two dimensional matrix multiplications.
+`A` matrix is of shape `N x H x C`.
+`B` matrix is of shape `D x W x C`.
+This is effectively a matrix multiply of `A` by the transposed `B` matrix.
+If the `D` dimension of input `B` is of size 1, the `B` matrix is broadcast.
+
+*Precision Requirements*
+
+Integer results must be exact.
+
+For floating-point values, the following rules apply:
+
+* Subnormal bf16_t, fp16_t, and fp32_t input values may be flushed to zero before calculation.
+* Each output can be expressed as a dot product of two input vectors.
+* The dot product must meet the <<Dot product accuracy requirements>>.
+
+include::{generated}/operators/MATMUL_T.adoc[]
+
+[source,c++]
+----
+include::{pseudocode}/operators/MATMUL_T.tosac[lines=10..-1]
+----
+
+==== MATMUL_T_BLOCK_SCALED (deprecated, removed in 1.1)
 
 Performs two dimensional matrix multiplications using block scaled tensors.
 The block dimension is always the the last dimension of the tensor, so the result is effectively a matrix multiply of A by the transposed B matrix.

--- a/pseudocode/library/generic_helpers.tosac
+++ b/pseudocode/library/generic_helpers.tosac
@@ -97,3 +97,19 @@ bool_t is_an_Inf(in_t value);
 
 // return true if value is a normal fp64 value (Not zero, subnormal, infinite or NaN)
 bool_t is_normal_fp64(fp64_t value);
+
+// Return if type has a member scale_t
+bool_t has_scale_t<in_t>();
+
+// Return if type has a member value_t
+bool_t has_value_t<in_t>();
+
+// Return true if this is valid construction of a block scaled tensor
+// Valid types are listed in an Operator's "Supported Data Types" section.
+bool_t is_valid_block_scale<in_t>();
+
+// Return true if a type is the logical type block_scale_t
+bool_t is_block_scale<in_t>() {
+    return ((has_value_t<in_t>() && has_scale_t<in_t>()) // must have members scale_t and value_t
+    && is_valid_block_scale<in_t>()) // must be a valid block scaled tensor type as allowed by the spec
+}

--- a/pseudocode/library/tensor_read.tosac
+++ b/pseudocode/library/tensor_read.tosac
@@ -1,7 +1,7 @@
 //
 // This confidential and proprietary software may be used only as
 // authorised by a licensing agreement from ARM Limited
-// (C) COPYRIGHT 2020-2024 ARM Limited
+// (C) COPYRIGHT 2020-2026 ARM Limited
 // ALL RIGHTS RESERVED
 // The entire notice above must be reproduced on all authorised
 // copies and copies may only be made to the extent permitted
@@ -11,3 +11,37 @@ in_t tensor_read<in_t>(in_t *address, shape_t shape, shape_t index) {
     tensor_size_t offset = tensor_index_to_offset(shape, index);
     return address[offset];
 }
+
+out_t tensor_read<in_t, out_t>(in_t *address, shape_t shape, shape_t index) {
+    if (!is_block_scale<in_t>()) {
+        return static_cast<out_t>(tensor_read<in_t>(address, shape, index));
+    }
+
+    block_size_t block_size = get_block_size<in_t>();
+
+    shape_t blk_shape = shape;
+    blk_shape[rank(shape) - 1] /= block_size;
+
+    shape_t blk_index = index;
+    blk_index[rank(index) - 1] /= block_size;
+
+    using value_t = get_value_t<in_t>();
+    using scale_t = get_scale_t<in_t>();
+
+    // NOTE: The following gives a layout of scales following values in a block-scaled tensor.
+    // This is not normative of a specific memory storage layout.
+    // An implementation is free to use a layout of its choice.
+    // However, an implementation must maintain the functional behaviour.
+    value_t* value_address = reinterpret_cast<value_t*>(address);
+    scale_t* scale_address = reinterpret_cast<scale_t*>(value_address + tensor_size(shape));
+
+    out_t value = static_cast<out_t>(tensor_read<value_t>(value_address, shape, index));
+    out_t scale = static_cast<out_t>(tensor_read<scale_t>(scale_address, blk_shape, blk_index));
+
+    return apply_mul_s<out_t>(scale, value);
+}
+
+// block read helpers
+block_size_t get_block_size<block_scale_t<>>();
+get_scale_t<block_scale_t<>>(); // scale_t
+get_value_t<block_scale_t<>>(); // value_t

--- a/pseudocode/operators/MATMUL_T.tosac
+++ b/pseudocode/operators/MATMUL_T.tosac
@@ -1,0 +1,44 @@
+//
+// This confidential and proprietary software may be used only as
+// authorised by a licensing agreement from ARM Limited
+// (C) COPYRIGHT 2026 ARM Limited
+// ALL RIGHTS RESERVED
+// The entire notice above must be reproduced on all authorised
+// copies and copies may only be made to the extent permitted
+// by a licensing agreement from ARM Limited.
+
+
+//
+// C is the contraction dimension.
+//
+// A has shape [N,H,C].
+// B has shape [D,W,C].
+//
+// D must be 1 or N.
+// If D is 1, B is broadcast.
+// Output has shape [N,H,W].
+
+ERROR_IF(D != N && D != 1);
+ERROR_IF(!is_same<A_t,i8_t>() && A_zp != 0);
+ERROR_IF(!is_same<B_t,i8_t>() && B_zp != 0);
+ERROR_IF(is_block_scale<A_t>() && C % A_t::block_size != 0);
+ERROR_IF(is_block_scale<B_t>() && C % B_t::block_size != 0);
+
+for_each(0 <= n < N, 0 <= h < H, 0 <= w < W) {
+    out_t acc = 0;
+    size_t d = (D == 1) ? 0 : n;
+
+    for_each(0 <= c < C) {
+        out_t value1 = tensor_read<A_t, out_t>(A, [N,H,C], [n,h,c]);
+        out_t value2 = tensor_read<B_t, out_t>(B, [D,W,C], [d,w,c]);
+
+        value1 = apply_sub_s<out_t>(value1, static_cast<out_t>(A_zp));
+        value2 = apply_sub_s<out_t>(value2, static_cast<out_t>(B_zp));
+
+        acc = apply_add_s<out_t>(
+            acc,
+            apply_mul_s<out_t>(value1, value2));
+    }
+
+    tensor_write<out_t>(output, [N,H,W], [n,h,w], acc);
+}

--- a/tools/compliance_data_exporter.py
+++ b/tools/compliance_data_exporter.py
@@ -1,7 +1,8 @@
-# Copyright (c) 2024-2025, ARM Limited.
+# Copyright (c) 2024-2026, ARM Limited.
 # SPDX-License-Identifier: Apache-2.0
 import os
 
+from tosa import deduce_extensions
 from tosa import TOSAOperator
 from tosa import TOSAOperatorArgument
 
@@ -46,6 +47,12 @@ validation_term_mapping_type = {
     "fp6e2m3_t": "fp6e2m3T",
     "fp4e2m1_t": "fp4e2m1T",
     "mxint8_t": "mxint8T",
+    "bs32_fp8ue8m0_fp8e4m3_t": "bs32_fp8ue8m0_fp8e4m3T",
+    "bs32_fp8ue8m0_fp8e5m2_t": "bs32_fp8ue8m0_fp8e5m2T",
+    "bs32_fp8ue8m0_fp6e3m2_t": "bs32_fp8ue8m0_fp6e3m2T",
+    "bs32_fp8ue8m0_fp6e2m3_t": "bs32_fp8ue8m0_fp6e2m3T",
+    "bs32_fp8ue8m0_fp4e2m1_t": "bs32_fp8ue8m0_fp4e2m1T",
+    "bs32_fp8ue8m0_mxint8_t": "bs32_fp8ue8m0_mxint8T",
 }
 
 
@@ -80,28 +87,37 @@ def get_profile_compliance_info(operator: TOSAOperator, print_mode: str) -> set:
     prof_info = {}
 
     for tysup in operator.typesupports:
-        prof_set = set()
-        tsmap = tysup.tymap
         version_added = tysup.version_added
+        base_prof_set = set()  # Should contain all extensions except DEDUCE-EXT
+        should_deduce = False
 
         for profs in tysup.profiles:
             profs = profs.split(" and ")
             for prof in profs:
+                if prof == "DEDUCE-EXT":
+                    should_deduce = True
+                    continue
                 if is_matched_print_mode(prof, print_mode):
-                    prof_set.add(prof)
+                    base_prof_set.add(prof)
 
-        if len(prof_set) == 0:
-            continue
+        for tsmap in tysup.generated_tuples:
+            prof_set = set(
+                base_prof_set
+            )  # Each tsmap can have its own deduced extensions
+            if should_deduce and print_mode == "Extension":
+                prof_set.update(deduce_extensions(tsmap))
 
-        prof_list = list(prof_set)
-        prof_list.sort()
-        prof_str = " ".join(prof_list)
+            if len(prof_set) == 0:
+                continue
 
-        if prof_str in prof_info.keys():
-            value = prof_info[prof_str]
-            value.append((tsmap, version_added))
-        else:
-            prof_info[prof_str] = [(tsmap, version_added)]
+            prof_list = list(prof_set)
+            prof_list.sort()
+            prof_str = " ".join(prof_list)
+
+            if prof_str in prof_info.keys():
+                prof_info[prof_str].append((tsmap, version_added))
+            else:
+                prof_info[prof_str] = [(tsmap, version_added)]
 
     return prof_info
 

--- a/tools/compliance_data_verifier.py
+++ b/tools/compliance_data_verifier.py
@@ -94,6 +94,7 @@ op_list = [
     "sub_shape",
     "cast_to_block_scaled",
     "cast_from_block_scaled",
+    "matmul_t",
     "matmul_t_block_scaled",
     "conv2d_block_scaled",
 ]
@@ -138,6 +139,12 @@ type_list = [
     "fp6e2m3T",
     "fp4e2m1T",
     "mxint8T",
+    "bs32_fp8ue8m0_fp8e4m3T",
+    "bs32_fp8ue8m0_fp8e5m2T",
+    "bs32_fp8ue8m0_fp6e3m2T",
+    "bs32_fp8ue8m0_fp6e2m3T",
+    "bs32_fp8ue8m0_fp4e2m1T",
+    "bs32_fp8ue8m0_mxint8T",
 ]
 
 cond_list = [

--- a/tools/genspec.py
+++ b/tools/genspec.py
@@ -2,7 +2,6 @@
 # Copyright (c) 2023-2024, 2026, ARM Limited.
 # SPDX-License-Identifier: Apache-2.0
 import os
-import re
 from functools import cmp_to_key
 
 import compliance_data_exporter
@@ -25,6 +24,104 @@ def compare_profiles(a, b):
 class TOSASpecAsciidocGenerator:
     def __init__(self, spec):
         self.spec = spec
+
+    def render_type_set(self, values):
+        scalar_values = []
+        set_aliases = []
+        for value in values:
+            if value in tosa.TYPE_SET_VALUE_EXPANSIONS:
+                set_aliases.append(value)
+            else:
+                scalar_values.append(value)
+
+        terms = []
+        if scalar_values:
+            terms.append("{" + ", ".join(scalar_values) + "}")
+        terms.extend(set_aliases)
+        return " \N{UNION} ".join(terms)
+
+    def get_operator_type_sets(self, op):
+        definitions = {}
+        for tysup in op.typesupports:
+            for set_name, values in tysup.type_sets:
+                values_tuple = tuple(values)
+                if set_name in definitions and definitions[set_name] != values_tuple:
+                    raise RuntimeError(
+                        f"Operator {op.name} reuses type set {set_name}"
+                        " with different values"
+                    )
+                definitions[set_name] = values_tuple
+        return definitions
+
+    def format_extension_note(self, other_exts):
+        if len(other_exts) == 0:
+            return ""
+        if len(other_exts) > 1:
+            return f"If {' and '.join(other_exts)} are also supported"
+        return f"If {other_exts[0]} is also supported"
+
+    def get_input_type_bindings(self, op, tysup):
+        bindings = []
+        for ty in op.types:
+            if ty not in tysup.type_bindings:
+                continue
+            for arg in op.arguments:
+                if not any(cat.name == "input" for cat in arg.categories):
+                    continue
+                if ty in (arg.tensor_element_type, arg.tensor_element_scale_type):
+                    bindings.append(ty)
+                    break
+
+        # If type_sets gets used in attributes, output etc. in future
+        if len(bindings) == 0:
+            bindings = [ty for ty in op.types if ty in tysup.type_bindings]
+
+        return bindings
+
+    def format_typesupport_mode(self, op, tysup, tsmap):
+        bindings = self.get_input_type_bindings(op, tysup)
+        if len(bindings) == 0:
+            return tysup.mode
+
+        binding_text = ", ".join(f"{ty} = {tsmap[ty]}" for ty in bindings)
+        return f"{tysup.mode} ({binding_text})"
+
+    def get_profile_extension_rows(self, op, tysup, extension_name):
+        rows = set()
+        for profile in tysup.profiles:
+            profile_exts = profile.split(" and ")
+            if "DEDUCE-EXT" in profile_exts:
+                if extension_name == "DEDUCE-EXT":
+                    continue
+                for tsmap in tysup.generated_tuples:
+                    deduced_exts = tosa.deduce_extensions(tsmap)
+                    if extension_name in deduced_exts:
+                        other_exts = tuple(
+                            sorted(ext for ext in deduced_exts if ext != extension_name)
+                        )
+                        rows.add(
+                            (
+                                self.format_typesupport_mode(op, tysup, tsmap),
+                                other_exts,
+                            )
+                        )
+                continue
+
+            if extension_name in profile_exts:
+                other_exts = tuple(
+                    sorted(ext for ext in profile_exts if ext != extension_name)
+                )
+                if len(tysup.type_bindings) > 0:
+                    for tsmap in tysup.generated_tuples:
+                        rows.add(
+                            (
+                                self.format_typesupport_mode(op, tysup, tsmap),
+                                other_exts,
+                            )
+                        )
+                else:
+                    rows.add((tysup.mode, other_exts))
+        return sorted(rows)
 
     def generate_enum(self, enum, file):
         file.write(f"\n=== {enum.name}\n")
@@ -122,6 +219,17 @@ class TOSASpecAsciidocGenerator:
 
         if op.typesupports:
             file.write("\n*Supported Data Types:*\n\n")
+            type_sets = self.get_operator_type_sets(op)
+            if len(type_sets) > 0:
+                file.write(
+                    "Named type sets denote a Cartesian product. "
+                    "If multiple type columns reference named sets, any combination "
+                    "formed by choosing one value from each referenced set is valid."
+                    "\n\n"
+                )
+                file.write("*Type Sets:*\n\n")
+                for set_name, values in type_sets.items():
+                    file.write(f"`{set_name} = {self.render_type_set(values)}`\n\n")
             file.write("|===\n")
             header = "|Profile/Extension|Mode"
             for ty in op.types:
@@ -130,11 +238,23 @@ class TOSASpecAsciidocGenerator:
             file.write("\n\n")
             for tysup in sorted(op.typesupports, key=cmp_to_key(compare_profiles)):
                 profile = " or ".join(tysup.profiles) if tysup.profiles else "Any"
-                entry = f"|{profile}|{tysup.mode}"
-                for ty in op.types:
-                    entry += f"|{tysup.tymap[ty]}"
-                entry += "\n"
-                file.write(entry)
+                if len(tysup.type_sets) > 0:
+                    entry = f"|{profile}|{tysup.mode}"
+                    for ty in op.types:
+                        if ty in tysup.type_bindings:
+                            entry += f"|{tysup.type_bindings[ty]}"
+                        else:
+                            entry += f"|{tysup.tymap[ty]}"
+                    entry += "\n"
+                    file.write(entry)
+                    continue
+
+                for tsmap in tysup.generated_tuples:
+                    entry = f"|{profile}|{tysup.mode}"
+                    for ty in op.types:
+                        entry += f"|{tsmap[ty]}"
+                    entry += "\n"
+                    file.write(entry)
             file.write("|===\n")
         file.write("\n*Operation Function:*\n\n")
         leveltext = ""
@@ -234,6 +354,7 @@ class TOSASpecAsciidocGenerator:
                 f.write("|===\n")
 
             f.write("=== Profile Extensions\n")
+            f.write("For `DEDUCE-EXT`, see <<Extension Data Type Mapping>>.\n\n")
             for pext in self.spec.profile_extensions:
                 f.write(f"==== {pext.name} extension\n")
                 f.write(f"{pext.description}\n\n")
@@ -246,34 +367,15 @@ class TOSASpecAsciidocGenerator:
                 for op in sorted(all_operators, key=lambda o: o.name):
                     if op.typesupports:
                         for tysup in op.typesupports:
-                            for profile in tysup.profiles:
-                                if profile.find(pext.name) != -1:
-                                    note = ""
-                                    m = re.match(
-                                        r"([a-zA-Z0-9-]+) and ([a-zA-Z0-9-]+)"
-                                        "(?: and ([a-zA-Z0-9-]+))?",
-                                        profile,
-                                    )
-                                    if m:
-                                        other_exts = list(
-                                            e
-                                            for e in m.groups()
-                                            if e != pext.name and e is not None
-                                        )
-                                        if len(other_exts) > 1:
-                                            note = (
-                                                f"If {' and '.join(other_exts)}"
-                                                " are also supported"
-                                            )
-                                        else:
-                                            note = (
-                                                f"If {other_exts[0]} is also supported"
-                                            )
-                                    f.write(
-                                        f"|{op.name}|{tysup.mode}|"
-                                        f"{tysup.version_added}|{note}\n"
-                                    )
-                                    op_changed = True
+                            for mode, other_exts in self.get_profile_extension_rows(
+                                op, tysup, pext.name
+                            ):
+                                note = self.format_extension_note(other_exts)
+                                f.write(
+                                    f"|{op.name}|{mode}|"
+                                    f"{tysup.version_added}|{note}\n"
+                                )
+                                op_changed = True
                     for arg in op.arguments:
                         if pext.name in arg.ctc_remove:
                             op_changed = True

--- a/tools/speclint.py
+++ b/tools/speclint.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-# Copyright (c) 2023-2024, ARM Limited.
+# Copyright (c) 2023-2026, ARM Limited.
 # SPDX-License-Identifier: Apache-2.0
 import tosa
 
@@ -49,11 +49,12 @@ class TOSASpecLinter:
     def lint_typesupport(self, typesupport, op):
         # Check that all types are defined for each typesupport
         # and that there are no extras
-        for t in typesupport.tymap:
-            if typesupport.tymap[t] is None:
-                self.WARN(
-                    f"Operator {op.name} mode {typesupport.mode} type {t} not found"
-                )
+        for tytuple in typesupport.generated_tuples:
+            for t in tytuple:
+                if tytuple[t] is None:
+                    self.WARN(
+                        f"Operator {op.name} mode {typesupport.mode} type {t} not found"
+                    )
         known_keys = ["mode", "version_added"]
         for k in typesupport.tskeys:
             if k not in known_keys and k not in op.types:

--- a/tools/tosa.py
+++ b/tools/tosa.py
@@ -1,8 +1,48 @@
 #!/usr/bin/env python3
 # Copyright (c) 2023,2026, ARM Limited.
 # SPDX-License-Identifier: Apache-2.0
+import itertools
 import re
 import xml.etree.ElementTree as ET
+
+
+TYPE_SET_VALUE_EXPANSIONS = {
+    "bs32_fp8ue8m0_set_t": (
+        "bs32_fp8ue8m0_fp8e4m3_t",
+        "bs32_fp8ue8m0_fp8e5m2_t",
+        "bs32_fp8ue8m0_fp6e3m2_t",
+        "bs32_fp8ue8m0_fp6e2m3_t",
+        "bs32_fp8ue8m0_fp4e2m1_t",
+        "bs32_fp8ue8m0_mxint8_t",
+    ),
+}
+
+DEDUCED_EXTENSION_TYPE_MAPPING = {
+    "i64_t": ["EXT-INT64"],
+    "i16_t": ["EXT-INT16"],
+    "i4_t": ["EXT-INT4"],
+    "bf16_t": ["EXT-BF16"],
+    "fp8e4m3_t": ["EXT-FP8E4M3"],
+    "fp8e5m2_t": ["EXT-FP8E5M2"],
+    "fp8ue8m0_t": ["EXT-MX-COMMON"],
+    "fp4e2m1_t": ["EXT-MX-FP4E2M1"],
+    "fp6e2m3_t": ["EXT-MX-FP6E2M3"],
+    "fp6e3m2_t": ["EXT-MX-FP6E3M2"],
+    "mxint8_t": ["EXT-MX-INT8"],
+    "bs32_fp8ue8m0_fp8e4m3_t": ["EXT-MX-COMMON", "EXT-MX-FP8E4M3"],
+    "bs32_fp8ue8m0_fp8e5m2_t": ["EXT-MX-COMMON", "EXT-MX-FP8E5M2"],
+    "bs32_fp8ue8m0_fp6e3m2_t": ["EXT-MX-COMMON", "EXT-MX-FP6E3M2"],
+    "bs32_fp8ue8m0_fp6e2m3_t": ["EXT-MX-COMMON", "EXT-MX-FP6E2M3"],
+    "bs32_fp8ue8m0_fp4e2m1_t": ["EXT-MX-COMMON", "EXT-MX-FP4E2M1"],
+    "bs32_fp8ue8m0_mxint8_t": ["EXT-MX-COMMON", "EXT-MX-INT8"],
+}
+
+
+def deduce_extensions(tsmap):
+    extensions = set()
+    for ty in tsmap.values():
+        extensions.update(DEDUCED_EXTENSION_TYPE_MAPPING.get(ty, []))
+    return extensions
 
 
 # possible shapes: shape1, [2], [N,H,W,C]
@@ -96,12 +136,32 @@ class TOSAOperatorArgument:
 
 
 class TOSAOperatorDataTypeSupport:
-    def __init__(self, mode, tymap, version_added, profiles, tskeys):
+    def __init__(
+        self,
+        mode,
+        generated_tuples,
+        version_added,
+        profiles,
+        tskeys,
+        type_sets=None,
+        type_bindings=None,
+    ):
+        if len(generated_tuples) == 0:
+            raise RuntimeError(f"Typesupport {mode} has no generated tuples")
         self.mode = mode
-        self.tymap = tymap
+        self.generated_tuples = [dict(tytuple) for tytuple in generated_tuples]
+        tuple_keys = set(self.generated_tuples[0].keys())
+        for tytuple in self.generated_tuples[1:]:
+            if set(tytuple.keys()) != tuple_keys:
+                raise RuntimeError(
+                    f"Typesupport {mode} has inconsistent generated tuple keys"
+                )
+        self.tymap = self.generated_tuples[0]  # For fixed type_support with no Sets
         self.profiles = profiles
         self.version_added = version_added
         self.tskeys = tskeys
+        self.type_sets = list(type_sets or [])
+        self.type_bindings = dict(type_bindings or {})
 
 
 class TOSAOperator:
@@ -229,12 +289,112 @@ class TOSASpec:
                 tsprofiles.append(tsp_name)
             for ty in types:
                 tsmap[ty] = tysup.get(ty)
+            type_sets = self.__load_typesupport_sets(tysup, name, tsmode)
+            expanded_type_sets = self.__expand_typesupport_sets(type_sets)
+            type_bindings = self.__load_typesupport_bindings(
+                tysup, name, tsmode, types, type_sets
+            )
+            generated_tuples = self.__expand_typesupport_tuples(
+                name, tsmode, types, tsmap, expanded_type_sets, type_bindings
+            )
             typesupports.append(
                 TOSAOperatorDataTypeSupport(
-                    tsmode, tsmap, version_added, tsprofiles, tskeys
+                    tsmode,
+                    generated_tuples,
+                    version_added,
+                    tsprofiles,
+                    tskeys,
+                    type_sets,
+                    type_bindings,
                 )
             )
         return TOSAOperator(name, args, types, typesupports)
+
+    def __load_typesupport_sets(self, tysup, op_name, mode):
+        type_sets = []
+        seen_names = set()
+        for type_set in tysup.findall("type_set"):
+            set_name = type_set.get("name")
+            if set_name in seen_names:
+                raise RuntimeError(
+                    f"Operator {op_name} mode {mode} repeats type set {set_name}"
+                )
+            values = type_set.get("values").split()
+            if len(values) == 0:
+                raise RuntimeError(
+                    f"Operator {op_name} mode {mode} has empty type set {set_name}"
+                )
+            type_sets.append((set_name, values))
+            seen_names.add(set_name)
+        return type_sets
+
+    def __expand_typesupport_sets(self, type_sets):
+        return [
+            (set_name, self.__expand_type_set_values(values))
+            for set_name, values in type_sets
+        ]
+
+    def __expand_type_set_values(self, values):
+        expanded = []
+        for value in values:
+            expanded.extend(TYPE_SET_VALUE_EXPANSIONS.get(value, (value,)))
+
+        deduplicated = []
+        for value in expanded:
+            if value not in deduplicated:
+                deduplicated.append(value)
+        return deduplicated
+
+    def __load_typesupport_bindings(self, tysup, op_name, mode, types, type_sets):
+        # See EXPECT_TYPESUPPORT comment in tosa.xsd
+        type_bindings = {}
+        known_sets = {set_name for set_name, _ in type_sets}
+        for type_bind in tysup.findall("type_bind"):
+            ty_name = type_bind.get("type")
+            set_name = type_bind.get("set")
+            if ty_name not in types:
+                raise RuntimeError(
+                    f"Operator {op_name} mode {mode} binds unknown type {ty_name}"
+                )
+            if ty_name in type_bindings:
+                raise RuntimeError(
+                    f"Operator {op_name} mode {mode} repeats binding for {ty_name}"
+                )
+            if set_name not in known_sets:
+                raise RuntimeError(
+                    f"Operator {op_name} mode {mode} "
+                    "references unknown type set {set_name}"
+                )
+            type_bindings[ty_name] = set_name
+        return type_bindings
+
+    def __expand_typesupport_tuples(
+        self, op_name, mode, types, tsmap, type_sets, type_bindings
+    ):
+        for ty_name in type_bindings:
+            if tsmap.get(ty_name) is not None:
+                raise RuntimeError(
+                    f"Operator {op_name} mode {mode} "
+                    "binds {ty_name} and sets it explicitly"
+                )
+
+        if len(type_bindings) == 0:
+            return [tsmap]
+
+        type_sets_map = {set_name: values for set_name, values in type_sets}
+        bound_types = [ty_name for ty_name in types if ty_name in type_bindings]
+        bound_value_lists = [
+            type_sets_map[type_bindings[ty_name]] for ty_name in bound_types
+        ]
+
+        generated_tuples = []
+        for bound_values in itertools.product(*bound_value_lists):
+            expanded = dict(tsmap)
+            for ty_name, value in zip(bound_types, bound_values):
+                expanded[ty_name] = value
+            generated_tuples.append(expanded)
+
+        return generated_tuples
 
     def __load_operator_argument(self, arg, op_name):
         name = arg.get("name")

--- a/tosa.xml
+++ b/tosa.xml
@@ -911,6 +911,79 @@
         </typesupport>
       </operator>
       <operator>
+        <name>MATMUL_T</name>
+        <arguments>
+          <argument category="input" name="A" type="tensor_t" shape="[N,H,C]" tensor-element-type="A_t">
+            <description>Input tensor A, N matrices of size HxC</description>
+            <rank min="3" max="3"/>
+          </argument>
+          <argument category="input" name="B" type="tensor_t" shape="[D,W,C]" tensor-element-type="B_t">
+            <description>Input tensor B, D matrices of size WxC. D must be either 1 or N. If D is 1, B is broadcast.</description>
+            <rank min="3" max="3"/>
+          </argument>
+          <argument category="input" name="A_zp" type="tensor_t" shape="[1]" tensor-element-type="i8_t">
+            <description>Input tensor A zero point. Must be zero unless A_t is i8_t.</description>
+            <rank min="1" max="1"/>
+            <ctc>
+              <op_profile name="PRO-INT"/>
+              <op_profile name="PRO-FP"/>
+            </ctc>
+            <ctc_remove>
+              <op_profile name="EXT-DYNAMIC"/>
+            </ctc_remove>
+          </argument>
+          <argument category="input" name="B_zp" type="tensor_t" shape="[1]" tensor-element-type="i8_t">
+            <description>Input tensor B zero point. Must be zero unless B_t is i8_t.</description>
+            <rank min="1" max="1"/>
+            <ctc>
+              <op_profile name="PRO-INT"/>
+              <op_profile name="PRO-FP"/>
+            </ctc>
+            <ctc_remove>
+              <op_profile name="EXT-DYNAMIC"/>
+            </ctc_remove>
+          </argument>
+          <argument category="output" name="output" type="tensor_t" shape="[N,H,W]" tensor-element-type="out_t">
+            <description>Output tensor, N matrices of size HxW</description>
+            <rank min="3" max="3"/>
+          </argument>
+        </arguments>
+        <types>
+          <type name='A_t' />
+          <type name='B_t' />
+          <type name='out_t' />
+        </types>
+        <typesupport mode="signed 8x8 with int32 accumulate" A_t="i8_t" B_t="i8_t" out_t="i32_t" version_added="1.1">
+          <op_profile name="PRO-INT"/>
+        </typesupport>
+        <typesupport mode="signed 16x16 with int48 accumulate" A_t="i16_t" B_t="i16_t" out_t="i48_t" version_added="1.1">
+          <op_profile name="EXT-INT16"/>
+        </typesupport>
+        <typesupport mode="Mixed precision fp with fp16 accumulate" out_t="fp16_t" version_added="1.1">
+          <op_profile name="DEDUCE-EXT"/>
+          <type_set name="S1_IN" values="fp8e4m3_t fp8e5m2_t fp16_t bf16_t bs32_fp8ue8m0_set_t"/>
+          <type_bind type="A_t" set="S1_IN"/>
+          <type_bind type="B_t" set="S1_IN"/>
+        </typesupport>
+        <typesupport mode="Mixed precision fp with fp32 accumulate" out_t="fp32_t" version_added="1.1">
+          <op_profile name="DEDUCE-EXT"/>
+          <type_set name="S2_IN" values="fp8e4m3_t fp8e5m2_t fp16_t bf16_t fp32_t bs32_fp8ue8m0_set_t"/>
+          <type_bind type="A_t" set="S2_IN"/>
+          <type_bind type="B_t" set="S2_IN"/>
+        </typesupport>
+        <typesupport mode="fp16xfp16 with fp16/fp32 accumulate" A_t="fp16_t" B_t="fp16_t" version_added="1.1">
+          <op_profile name="PRO-FP"/>
+          <type_set name="S_FP16_OUT" values="fp16_t fp32_t"/>
+          <type_bind type="out_t" set="S_FP16_OUT"/>
+        </typesupport>
+        <typesupport mode="bf16xbf16 with fp32 accumulate" A_t="bf16_t" B_t="bf16_t" out_t="fp32_t" version_added="1.1">
+          <op_profile name="EXT-BF16"/>
+        </typesupport>
+        <typesupport mode="fp32xfp32 with fp32 accumulate" A_t="fp32_t" B_t="fp32_t" out_t="fp32_t" version_added="1.1">
+          <op_profile name="PRO-FP"/>
+        </typesupport>
+      </operator>
+      <operator>
         <name>MATMUL_T_BLOCK_SCALED</name>
         <arguments>
           <argument category="input" name="A_data" type="tensor_t" shape="[N,H,C]" tensor-element-type="A_t">

--- a/tosa.xsd
+++ b/tosa.xsd
@@ -37,6 +37,7 @@
     <xs:enumeration value="EXT-DYNAMIC"/>
     <xs:enumeration value="EXT-DOUBLEROUND"/>
     <xs:enumeration value="EXT-INEXACTROUND"/>
+    <xs:enumeration value="DEDUCE-EXT"/>
     <xs:enumeration value="EXT-MX-COMMON"/>
     <xs:enumeration value="EXT-MX-FP4E2M1"/>
     <xs:enumeration value="EXT-MX-FP6E2M3"/>
@@ -89,6 +90,12 @@
     <xs:enumeration value="fp32_t"/>
     <xs:enumeration value="mxint8_t"/>
     <xs:enumeration value="tensor_size_t"/>
+    <xs:enumeration value="bs32_fp8ue8m0_fp8e4m3_t"/>
+    <xs:enumeration value="bs32_fp8ue8m0_fp8e5m2_t"/>
+    <xs:enumeration value="bs32_fp8ue8m0_fp6e3m2_t"/>
+    <xs:enumeration value="bs32_fp8ue8m0_fp6e2m3_t"/>
+    <xs:enumeration value="bs32_fp8ue8m0_fp4e2m1_t"/>
+    <xs:enumeration value="bs32_fp8ue8m0_mxint8_t"/>
   </xs:restriction>
 </xs:simpleType>
 
@@ -165,6 +172,24 @@
 
 <xs:simpleType name="argument-tensor-element-scale-type">
   <xs:union memberTypes="datatype typename enumtypename"/>
+</xs:simpleType>
+
+<xs:simpleType name="datatype-list">
+  <xs:list itemType="datatype"/>
+</xs:simpleType>
+
+<xs:simpleType name="datatype-set-alias">
+  <xs:restriction base="xs:string">
+    <xs:enumeration value="bs32_fp8ue8m0_set_t"/>
+  </xs:restriction>
+</xs:simpleType>
+
+<xs:simpleType name="type-set-value">
+  <xs:union memberTypes="datatype datatype-set-alias"/>
+</xs:simpleType>
+
+<xs:simpleType name="type-set-value-list">
+  <xs:list itemType="type-set-value"/>
 </xs:simpleType>
 
 <!-- Element definitions -->
@@ -368,6 +393,20 @@
   </xs:complexType>
 </xs:element>
 
+<xs:element name="type_set">
+  <xs:complexType>
+    <xs:attribute name="name" type="xs:string" use="required"/>
+    <xs:attribute name="values" type="type-set-value-list" use="required"/>
+  </xs:complexType>
+</xs:element>
+
+<xs:element name="type_bind">
+  <xs:complexType>
+    <xs:attribute name="type" type="typename" use="required"/>
+    <xs:attribute name="set" type="xs:string" use="required"/>
+  </xs:complexType>
+</xs:element>
+
 <xs:element name="types">
   <xs:complexType>
     <xs:sequence>
@@ -376,11 +415,21 @@
   </xs:complexType>
 </xs:element>
 
+<!-- EXPECT_TYPESUPPORT:
+If a symbolic datatype is expanded through a named type set, it must appear
+only as a <type_bind> target, with values supplied by <type_set>. The same
+symbolic datatype must _not_ also be set explicitly as a <typesupport>
+attribute such as A_t="...".
+Non-symbolic datatype(s) must appear as attribute in <typesupport>.
+-->
+
 <xs:element name="typesupport">
   <xs:complexType>
-    <xs:choice minOccurs="1" maxOccurs="unbounded">
-      <xs:element ref="op_profile"/>
-    </xs:choice>
+    <xs:sequence>
+      <xs:element ref="op_profile" minOccurs="1" maxOccurs="unbounded"/>
+      <xs:element ref="type_set" minOccurs="0" maxOccurs="unbounded"/>
+      <xs:element ref="type_bind" minOccurs="0" maxOccurs="unbounded"/>
+    </xs:sequence>
     <xs:attribute name="mode" type="xs:string" use="required"/>
     <xs:attribute name="version_added" type="xs:string" use="required"/>
     <xs:attribute name="in_t" type="datatype"/>


### PR DESCRIPTION
* Introduce logical type block_scale_t and define all derivable concrete types from it based on scale and value types
* Add MATMUL_T to support mixed FP types as inputs
* Introduce set notation to describe mixed FP types to avoid enumerating every possible combination
* Add logic in python scripts to parse and use this set notation alongside other concrete data types


Change-Id: I3eb8ea3f8ce01267674acc607611954584f5028d