### PR TITLE
Fix MX common extension naming in compliance data exporter and verifier

### DIFF
--- a/tools/compliance_data_exporter.py
+++ b/tools/compliance_data_exporter.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2024-2025, ARM Limited.
+# Copyright (c) 2024-2026, ARM Limited.
 # SPDX-License-Identifier: Apache-2.0
 import os
 
@@ -18,7 +18,7 @@ validation_term_mapping_profile = {
     "EXT-FFT": "Extension::fft",
     "EXT-SHAPE": "Extension::shape",
     "EXT-VARIABLE": "Extension::variable",
-    "EXT-MX-COMMON": "Extension::mxfp_common",
+    "EXT-MX-COMMON": "Extension::mx_common",
     "EXT-MX-FP4E2M1": "Extension::mx_fp4e2m1",
     "EXT-MX-FP6E2M3": "Extension::mx_fp6e2m3",
     "EXT-MX-FP6E3M2": "Extension::mx_fp6e3m2",

--- a/tools/compliance_data_verifier.py
+++ b/tools/compliance_data_verifier.py
@@ -110,7 +110,7 @@ profile_list = [
     "Extension::fft",
     "Extension::variable",
     "Extension::shape",
-    "Extension::mxfp_common",
+    "Extension::mx_common",
     "Extension::mx_fp4e2m1",
     "Extension::mx_fp6e2m3",
     "Extension::mx_fp6e3m2",


### PR DESCRIPTION
Previously the name did not reflect the naming of the extension in the specification.