### PR TITLE
Replace block_size with block_shape semantically

### DIFF
--- a/chapters/introduction.adoc
+++ b/chapters/introduction.adoc
@@ -377,13 +377,13 @@ Signed zero must be supported.
 | +1 + 63/64
 | 8-bit integer format with an implicit 1/64 scale defined by <<OCP-MX,OCP-MX>>. +
 
-|block_scale_t<block_size_t block_size, scale_t, value_t>.
+|block_scale_t<block_shape_t block_shape, scale_t, value_t>.
 |-
 |-
 | Block scaled type. +
 This does not specify an implementation type. +
 A tensor of this type is a tensor which has block-scaled quantization applied. +
-The type is made up of 3 components: block_size_t, scale_t, value_t. +
+The type is made up of 3 components: block_shape_t, scale_t, value_t. +
 Each of these types will be made evident in an Operator where they are used.
 |===
 
@@ -397,15 +397,15 @@ This ensures that an Integer profile TOSA implementation can calculate the same 
 .Supported Number Format Sets
 [cols="1,2,2,2,3,5"]
 |===
-|Set|Template|Allowed block_size_t|Allowed scale_t|Allowed value_t|Resulting block scaled data types
+|Set|Template|Allowed block_shape_t|Allowed scale_t|Allowed value_t|Resulting block scaled data types
 
 |bs32_fp8ue8m0_set_t
-|`block_scale_t<block_size_t block_size, scale_t, value_t>`
-|`BLOCK_SIZE_32`
+|`block_scale_t<block_shape_t block_shape, scale_t, value_t>`
+|`BLOCK_SHAPE_32`
 |`fp8ue8m0_t`
 |`fp8e4m3_t`, `fp8e5m2_t`, `fp6e3m2_t`, `fp6e2m3_t`, `fp4e2m1_t`, `mxint8_t`
-|A new data type is formed by instantiating the template with an allowed choice of `block_size_t`, `scale_t`, and `value_t`. +
-The resulting data type is named `bs<block size>_<scale type>_<value type>_t` where block size is the integer block size, scale type is scale_t without the _t suffix, and value type is the value_t without the _t suffix. +
+|A new data type is formed by instantiating the template with an allowed choice of `block_shape_t`, `scale_t`, and `value_t`. +
+The resulting data type is named `bs<block shape>_<scale type>_<value type>_t` where block shape indicates the size of innermost dimension(s), scale type is scale_t without the _t suffix, and value type is the value_t without the _t suffix. +
 The set of allowed block scaled data types is: +
 `bs32_fp8ue8m0_fp8e4m3_t`, +
 `bs32_fp8ue8m0_fp8e5m2_t`, +
@@ -469,27 +469,27 @@ The following table lists the composite block-scaled data types derived from the
 |Composite data type |Template instantiation |Deduced extension(s)
 
 |bs32_fp8ue8m0_fp8e4m3_t
-|`block_scale_t<BLOCK_SIZE_32, fp8ue8m0_t, fp8e4m3_t>`
+|`block_scale_t<BLOCK_SHAPE_32, fp8ue8m0_t, fp8e4m3_t>`
 |EXT-MX-COMMON and EXT-MX-FP8E4M3
 
 |bs32_fp8ue8m0_fp8e5m2_t
-|`block_scale_t<BLOCK_SIZE_32, fp8ue8m0_t, fp8e5m2_t>`
+|`block_scale_t<BLOCK_SHAPE_32, fp8ue8m0_t, fp8e5m2_t>`
 |EXT-MX-COMMON and EXT-MX-FP8E5M2
 
 |bs32_fp8ue8m0_fp6e3m2_t
-|`block_scale_t<BLOCK_SIZE_32, fp8ue8m0_t, fp6e3m2_t>`
+|`block_scale_t<BLOCK_SHAPE_32, fp8ue8m0_t, fp6e3m2_t>`
 |EXT-MX-COMMON and EXT-MX-FP6E3M2
 
 |bs32_fp8ue8m0_fp6e2m3_t
-|`block_scale_t<BLOCK_SIZE_32, fp8ue8m0_t, fp6e2m3_t>`
+|`block_scale_t<BLOCK_SHAPE_32, fp8ue8m0_t, fp6e2m3_t>`
 |EXT-MX-COMMON and EXT-MX-FP6E2M3
 
 |bs32_fp8ue8m0_fp4e2m1_t
-|`block_scale_t<BLOCK_SIZE_32, fp8ue8m0_t, fp4e2m1_t>`
+|`block_scale_t<BLOCK_SHAPE_32, fp8ue8m0_t, fp4e2m1_t>`
 |EXT-MX-COMMON and EXT-MX-FP4E2M1
 
 |bs32_fp8ue8m0_mxint8_t
-|`block_scale_t<BLOCK_SIZE_32, fp8ue8m0_t, mxint8_t>`
+|`block_scale_t<BLOCK_SHAPE_32, fp8ue8m0_t, mxint8_t>`
 |EXT-MX-COMMON and EXT-MX-INT8
 |===
 
@@ -616,8 +616,8 @@ The positions of `in[k]`, `w[k]`, `b` in the input, weight and bias tensors depe
 This may be, for example, a convolution.
 
 In a block-scaled dot product, each input and weight element `in[k]` and `w[k]` are scaled based on the corresponding scale values:
-`in[k] = in_data[k] * in_scale[k/block_size]`
-`w[k]  = w_data[k] * w_scale[k/block_size]`
+`in[k] = in_data[k] * in_scale[k/get_innermost_block_size<in_t>()]`
+`w[k]  = w_data[k] * w_scale[k/get_innermost_block_size<weight_t>()]`
 
 This section defines the accuracy required for these operations.
 In this section:

--- a/pseudocode/library/tensor_read.tosac
+++ b/pseudocode/library/tensor_read.tosac
@@ -17,13 +17,13 @@ out_t tensor_read<in_t, out_t>(in_t *address, shape_t shape, shape_t index) {
         return static_cast<out_t>(tensor_read<in_t>(address, shape, index));
     }
 
-    block_size_t block_size = get_block_size<in_t>();
+    size_t innermost_block_size = get_innermost_block_size<in_t>();
 
-    shape_t blk_shape = shape;
-    blk_shape[rank(shape) - 1] /= block_size;
+    shape_t scale_shape = shape;
+    scale_shape[rank(shape) - 1] /= innermost_block_size;
 
-    shape_t blk_index = index;
-    blk_index[rank(index) - 1] /= block_size;
+    shape_t scale_index = index;
+    scale_index[rank(index) - 1] /= innermost_block_size;
 
     using value_t = get_value_t<in_t>();
     using scale_t = get_scale_t<in_t>();
@@ -36,12 +36,7 @@ out_t tensor_read<in_t, out_t>(in_t *address, shape_t shape, shape_t index) {
     scale_t* scale_address = reinterpret_cast<scale_t*>(value_address + tensor_size(shape));
 
     out_t value = static_cast<out_t>(tensor_read<value_t>(value_address, shape, index));
-    out_t scale = static_cast<out_t>(tensor_read<scale_t>(scale_address, blk_shape, blk_index));
+    out_t scale = static_cast<out_t>(tensor_read<scale_t>(scale_address, scale_shape, scale_index));
 
     return apply_mul_s<out_t>(scale, value);
 }
-
-// block read helpers
-block_size_t get_block_size<block_scale_t<>>();
-get_scale_t<block_scale_t<>>(); // scale_t
-get_value_t<block_scale_t<>>(); // value_t

--- a/pseudocode/library/type_conversion_helpers.tosac
+++ b/pseudocode/library/type_conversion_helpers.tosac
@@ -1,7 +1,7 @@
 //
 // This confidential and proprietary software may be used only as
 // authorised by a licensing agreement from ARM Limited
-// (C) COPYRIGHT 2020-2024 ARM Limited
+// (C) COPYRIGHT 2020-2024,2026 ARM Limited
 // ALL RIGHTS RESERVED
 // The entire notice above must be reproduced on all authorised
 // copies and copies may only be made to the extent permitted
@@ -59,17 +59,27 @@ out_t bitcast<out_t>(in_t value)
 
 // Find the maximum absolute value for a block of the input tensor
 
-in_t tensor_block_maxabs(in_t *address, shape_t shape, shape_t index, i32_t block_size) {
+in_t tensor_block_maxabs(in_t *address, shape_t shape, shape_t index, i32_t innermost_block_size) {
     ERROR_IF(rank(shape) == 0);
-    ERROR_IF(shape[rank(shape)-1] % block_size != 0);
+    ERROR_IF(shape[rank(shape)-1] % innermost_block_size != 0);
     int r = rank(shape);
-    size_t min_i = floor(index[r - 1] / block_size) * block_size;
+    size_t min_i = floor(index[r - 1] / innermost_block_size) * innermost_block_size;
     in_t max_abs = 0;
-    for (size_t i = min_i; i < min_i + block_size; i++) {
+    for (size_t i = min_i; i < min_i + innermost_block_size; i++) {
         shape_t index_i = index;
         index_i[r - 1] = i;
         in_t v = tensor_read<in_t>(address, shape, index_i);
         max_abs = apply_max_s(max_abs, abs(v));
     }
     return max_abs;
+}
+
+// block read helpers
+get_scale_t<block_scale_t<>>(); // scale_t
+get_value_t<block_scale_t<>>(); // value_t
+
+size_t get_innermost_block_size<in_t>() {
+    REQUIRE(is_block_scale<in_t>());
+
+    // Return block size for innermost dimension
 }

--- a/pseudocode/operators/MATMUL_T.tosac
+++ b/pseudocode/operators/MATMUL_T.tosac
@@ -21,8 +21,8 @@
 ERROR_IF(D != N && D != 1);
 ERROR_IF(!is_same<A_t,i8_t>() && A_zp != 0);
 ERROR_IF(!is_same<B_t,i8_t>() && B_zp != 0);
-ERROR_IF(is_block_scale<A_t>() && C % A_t::block_size != 0);
-ERROR_IF(is_block_scale<B_t>() && C % B_t::block_size != 0);
+ERROR_IF(is_block_scale<A_t>() && C % get_innermost_block_size<A_t>() != 0);
+ERROR_IF(is_block_scale<B_t>() && C % get_innermost_block_size<B_t>() != 0);
 
 for_each(0 <= n < N, 0 <= h < H, 0 <= w < W) {
     out_t acc = 0;

--- a/tosa.xml
+++ b/tosa.xml
@@ -4924,7 +4924,16 @@ used.</description>
     <enumval value="3" name="DOUBLE_ROUND" description="Perform double rounding." extension="EXT-DOUBLEROUND"/>
  </enum>
 
-<enum name="block_size_t" description="Block size for the block_scaled formats">
+<enum name="block_shape_t" description="Block shape for the block_scaled formats. The names follow the convention of BLOCK_SHAPE_M where M is the block size of the innermost dimension. Similarly, BLOCK_SHAPE_MxN indicates block size of N in the innermost dimension and block size of M in the next innermost dimension. As of now, only 1 dimension (innermost) is supported for block-scaling.">
+  <enumval value="32" name="BLOCK_SHAPE_32" description="Block shape with innermost dimension of size 32" extension="EXT-MX-COMMON"/>
+<!--
+    NOTE: While extending these enum, check if following need updating:
+    - All call-sites of `get_innermost_block_size<in_t>()`
+-->
+</enum>
+
+<!-- This enum is deprecated and will be removed for 1.1 -->
+<enum name="block_size_t" description="Block size for the block_scaled formats (deprecated and will be removed for 1.1)">
   <enumval value="32" name="BLOCK_SIZE_32" description="Block size of 32" extension="EXT-MX-COMMON"/>
   <enumval value="1" name="BLOCK_SIZE_1" description="Block size of 1" extension="EXT-MX-COMMON"/>
 </enum>

--- a/tosa.xsd
+++ b/tosa.xsd
@@ -144,7 +144,8 @@
     <xs:enumeration value="A_t"/>
     <xs:enumeration value="acc_type_t"/>
     <xs:enumeration value="B_t"/>
-    <xs:enumeration value="block_size_t"/>
+    <xs:enumeration value="block_shape_t"/>
+    <xs:enumeration value="block_size_t"/> <!-- This enum is deprecated and will be removed for 1.1 -->
     <xs:enumeration value="bool_t"/>
     <xs:enumeration value="i8_t"/>
     <xs:enumeration value="i32_t"/>


### PR DESCRIPTION
* In pseudocode, replace use of block_size with get_innermost_block_size<T>()
* For soon to be deprecated _BLOCK_SCALED Ops, block shape concept is not applied


Change-Id: I943b042f9da85e57a56d17c18a3af9dc1a7ed6b8