### PR TITLE
Remove specification status line

### DIFF
--- a/chapters/introduction.adoc
+++ b/chapters/introduction.adoc
@@ -178,8 +178,6 @@ include::{generated}/levels.adoc[]
 
 === Status
 
-This specification is the release candidate for TOSA 1.0.
-
 The specific status of each profile and extension is contained in the tables in <<Profiles>>.
 Possible values for status are:
 


### PR DESCRIPTION
This line is outdated as it references the release candidate for v1.0 which has since been released.
Rather than update, it seems reasonable to remove and rely on the document title instead to indicate the current specification version and release/draft status.