### PR TITLE
Unify compliance metadata

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 #
 # This confidential and proprietary software may be used only as
 # authorised by a licensing agreement from ARM Limited
-# (C) COPYRIGHT 2020-2024 ARM Limited
+# (C) COPYRIGHT 2020-2024,2026 ARM Limited
 # ALL RIGHTS RESERVED
 # The entire notice above must be reproduced on all authorised
 # copies and copies may only be made to the extent permitted
@@ -81,8 +81,7 @@ out/lint.txt: $(SPECXML) $(SPECSCHEMA)
 $(GEN): $(SPECXML) $(GENSCRIPTS)
 	mkdir -p $(GENDIR)
 	tools/genspec.py --xml $(SPECXML) --outdir $(GENDIR) --profile
-	python3 tools/compliance_data_verifier.py --input $(GENDIR)/compliance.profile.meta
-	python3 tools/compliance_data_verifier.py --input $(GENDIR)/compliance.extension.meta
+	python3 tools/compliance_data_verifier.py --input $(GENDIR)/compliance.meta
 	@touch $@
 
 $(HTMLDIR)/tosa_spec.html: $(SPECSRC) $(SPECFILES) $(GEN) $(PSEUDOCODEFILES)

--- a/tools/compliance_data_exporter.py
+++ b/tools/compliance_data_exporter.py
@@ -310,15 +310,14 @@ def export_operator(operator: TOSAOperator, file, print_mode: str) -> None:
 
 
 def print_profiles_extensions(spec, outdir):
-    with open(os.path.join(outdir, "compliance.profile.meta"), "w") as f:
-        f.write("const OperationProfileComplianceMap profileComplianceMap = {\n")
+    with open(os.path.join(outdir, "compliance.meta"), "w") as f:
+        f.write("profileComplianceMap = {\n")
         for group in spec.operatorgroups:
             for op in group.operators:
                 export_operator(op, f, "Profile")
         f.write("};\n\n")
 
-    with open(os.path.join(outdir, "compliance.extension.meta"), "w") as f:
-        f.write("const OperationExtensionComplianceMap extensionComplianceMap = {\n")
+        f.write("extensionComplianceMap = {\n")
         for group in spec.operatorgroups:
             for op in group.operators:
                 export_operator(op, f, "Extension")


### PR DESCRIPTION
In the dialect, a single `TosaProfileCompliance.h.inc` file contains all profile/extension compliance information, yet the specficiation produced two separate files. This commit ensures only one file is produced to make it easier to copy the generated results.