### PR TITLE
Use is_finite in reference_check

### DIFF
--- a/pseudocode/library/generic_helpers.tosac
+++ b/pseudocode/library/generic_helpers.tosac
@@ -102,8 +102,8 @@ bool_t is_a_NaN(in_t value);
 // return true if the given value is an Infinity. Only valid for floating-point types with defined Infinity values.
 bool_t is_an_Inf(in_t value);
 
-// return true if value is a normal fp64 value (Not zero, subnormal, infinite or NaN)
-bool_t is_normal_fp64(fp64_t value);
+// return true if the given value is not an Infinity or NaN. Only valid for floating-point types
+bool_t is_finite(in_t value);
 
 // Return if type has a member scale_t
 bool_t has_scale_t<in_t>();

--- a/pseudocode/library/tosa_reference_check.tosac
+++ b/pseudocode/library/tosa_reference_check.tosac
@@ -1,7 +1,7 @@
 //
 // This confidential and proprietary software may be used only as
 // authorised by a licensing agreement from ARM Limited
-// (C) COPYRIGHT 2020-2025 ARM Limited
+// (C) COPYRIGHT 2020-2026 ARM Limited
 // ALL RIGHTS RESERVED
 // The entire notice above must be reproduced on all authorised
 // copies and copies may only be made to the extent permitted
@@ -11,7 +11,7 @@ bool_t tosa_reference_check_fp<in_t>(in_t test_value, fp64_t ref_value, fp64_t n
   fp64_t val_ulp = 0.0;
   if (is_same<in_t, mxint8_t>()) {
     val_ulp = 1 / 64.0;
-  } else if (is_normal_fp64(ref_value) && abs(ref_value) != 0) {
+  } else if (is_finite(ref_value) && abs(ref_value) != 0) {
     int ref_exp = ilog2(abs(ref_value));
     fp64_t ref_pow2 = max(exp2(ref_exp), normal_min<in_t>());
     val_ulp  = ref_pow2 * exp2(-normal_frac<in_t>());
@@ -24,7 +24,7 @@ bool_t tosa_reference_check_fp<in_t>(in_t test_value, fp64_t ref_value, fp64_t n
 // Check the conversion from block scaled
 bool_t tosa_reference_check_from_block<in_t, out_t>(out_t test_value, fp64_t ref_value, fp64_t scale) {
   fp64_t err_bnd = 0.0;
-  if (is_normal_fp64(ref_value) && abs(ref_value) != 0 && !is_a_NaN(scale)) {
+  if (is_finite(ref_value) && abs(ref_value) != 0 && !is_a_NaN(scale)) {
     int ref_exp = ilog2(abs(ref_value / scale));
     fp64_t ref_pow2 = max(exp2(ref_exp), normal_min<out_t>());
     fp64_t val_ulp = ref_pow2 * exp2(-normal_frac<out_t>());


### PR DESCRIPTION
Previously we were using is_normal_fp64 in a way that would set the error bound to `0.0` when the reference value was a subnormal in fp64_t.

This would mean that we don't allow any error at all in these cases, other than allowing the subnormal to be flushed to 0 for fp16_t, bf16_t and fp32_t.

For types that allow subnormals, this would disregard the error that should be allowed in the direction away from zero. For types that don't allow flushing to zero, this makes the condition impossible to meet, since fp64_t subnormals cannot be represented exactly in those types.

By changing is_normal_fp64 to is_finite, we now compute error bounds in the usual way for subnormal fp64 reference values.


Change-Id: I7f7f143ce3a6d4964dd4a357bb09ae3ae6bb937b