### PR TITLE
Relax backwards compatibility for defaulted optional attributes

### DIFF
--- a/chapters/introduction.adoc
+++ b/chapters/introduction.adoc
@@ -123,6 +123,7 @@ Changes to the following do not break compatibility:
 * Descriptive text that does not affect functionality
 * Non-functional changes to pseudocode (for example: cleanup, variable name changes)
 * Additions of new rows to the Supported Data Type tables
+* Additions of optional operator attributes with specified default values
 
 Minor versions are allowed to add new operators or other functionality as long as the above guarantees hold.
 


### PR DESCRIPTION
Allow minor versions to add optional operator attributes when the added attribute has a specified default value. Existing graphs preserve the same validity and behavior because omitted attributes take the default.