### PR TITLE
Add CAST input_unsigned attribute

### DIFF
--- a/chapters/introduction.adoc
+++ b/chapters/introduction.adoc
@@ -752,7 +752,7 @@ Unless otherwise specified, these values will be interpreted as signed two's-com
 The pseudocode will use int*_t to indicate use as a signed value and uint*_t to indicate use as an unsigned value.
 If overflow occurs doing integer calculation, the result is unpredictable, as indicated by the REQUIRE checks in the pseudocode for the operators.
 
-Unsigned 8- and 16-bit values are only allowed in the RESCALE operation, to allow for compatibility with networks which expect unsigned 8-bit or 16-bit tensors for input and output.
+Unsigned interpretation of signless integer values is only allowed where an operation explicitly defines it, such as RESCALE input and output unsigned attributes and the CAST `input_unsigned` attribute.
 
 ==== Quantization
 

--- a/chapters/introduction.adoc
+++ b/chapters/introduction.adoc
@@ -123,6 +123,7 @@ Changes to the following do not break compatibility:
 * Descriptive text that does not affect functionality
 * Non-functional changes to pseudocode (for example: cleanup, variable name changes)
 * Additions of new rows to the Supported Data Type tables
+* Additions of optional operator attributes with specified default values
 
 Minor versions are allowed to add new operators or other functionality as long as the above guarantees hold.
 

--- a/chapters/type_conversion.adoc
+++ b/chapters/type_conversion.adoc
@@ -17,7 +17,7 @@ include::{generated}/operators/CAST.adoc[]
 
 *Precision Requirements*
 
-When casting between integer types, the results must be exact.
+When casting between integer types, the results must exactly match the integer conversion behavior in the pseudocode. This includes sign extension for widening, truncation for narrowing, and zero extension of the input bit pattern when `input_unsigned` is true.
 
 Rules when casting between floating-point types:
 
@@ -65,7 +65,7 @@ Rules when casting between different types:
 ** Conversion must use the round to nearest, ties to even rounding mode.
 * Casting from integer to floating-point:
 ** Let `out_imp` be the implementation output.
-** Let `out_ref` be the result calculated using fp64_t arithmetic.
+** Let `out_ref` be the result calculated using fp64_t arithmetic. If `input_unsigned` is true, `out_ref` is calculated from the unsigned mathematical value of the input element.
 ** Then `tosa_reference_check_fp<out_t>(out_imp, out_ref, 0.5)` must be true.
 * Casting to boolean type:
 ** The result must be exact.

--- a/pseudocode/operators/CAST.tosac
+++ b/pseudocode/operators/CAST.tosac
@@ -13,6 +13,8 @@ ERROR_IF(is_block_scale<in_t>() && shape[rank(shape)-1] % get_innermost_block_si
 ERROR_IF(is_block_scale<out_t>() && rank(shape) == 0); // A scalar can't be cast to block_scale_t
 ERROR_IF(is_block_scale<out_t>() && shape[rank(shape)-1] % get_innermost_block_size<out_t>() != 0);
 
+ERROR_IF(input_unsigned && !is_integer<in_t>());
+
 if (is_block_scale<out_t>()) {
     ERROR_IF(is_floating_point<in_t>()); // Only allow FP to cast to Mx
 
@@ -39,12 +41,19 @@ if (is_block_scale<out_t>()) {
         out_t out;
         if (is_same<out_t,bool_t>()) {
             out = (in != 0) ? true : false;
+        } else if (input_unsigned) {
+            uint64_t unsigned_in = zero_extend<uint64_t>(in);
+            if (is_floating_point<out_t>()) {
+                out = round_to_nearest_float<uint64_t, out_t>(unsigned_in);
+            } else {
+                out = truncate<out_t>(unsigned_in);
+            }
         } else if (is_floating_point<out_t>()) {
             // Conversion to float cases
             if (is_same<acc_t,bool_t>()) {
                 out = (in) ? 1.0 : 0.0;
             } else {
-                out = round_to_nearest_float<out_t>(in);
+                out = round_to_nearest_float<acc_t, out_t>(in);
             }
         } else {
             // Conversion to integer cases

--- a/tosa.xml
+++ b/tosa.xml
@@ -3834,6 +3834,13 @@ used.</description>
             <levellimit value="rank(shape)" limit="MAX_RANK"/>
             <rank min="0" max="MAX_RANK"/>
           </argument>
+          <argument category="attribute" name="input_unsigned" type="bool_t" shape="-" tensor-element-type="-" optional="true">
+            <description>
+                This optional argument defaults to false.
+                If true, supported signless integer input values are interpreted as unsigned before conversion.
+                This is only valid for supported CAST type pairs with signless integer input.
+            </description>
+          </argument>
           <argument category="output" name="output" type="tensor_t" shape="shape" tensor-element-type="out_t">
             <description>Output tensor</description>
             <rank min="0" max="MAX_RANK"/>


### PR DESCRIPTION
Extend CAST with an optional input_unsigned attribute defaulting to false.
When set, supported signless integer inputs are interpreted as unsigned before
conversion, enabling zero-extension behavior for widening casts while preserving
existing CAST behavior by default.


Note:

This PR depends on https://github.com/arm/tosa-specification/pull/70